### PR TITLE
Use Proper Dependencies in Podspec

### DIFF
--- a/PFIncrementalStore.podspec
+++ b/PFIncrementalStore.podspec
@@ -16,5 +16,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.dependency 'Parse-iOS-SDK'
+  s.ios.dependency 'Parse-iOS-SDK'
+  s.osx.dependency 'Parse-OSX-SDK'
 end


### PR DESCRIPTION
We're currently using the Parse iOS SDK on both the iOS and OS X
platform, however we should be using the appropriate SDKS for the
platforms.
