### PR TITLE
Connect PFIncrementalStore with backingPersistentStoreCoordinator

### DIFF
--- a/PFIncrementalStore/PFIncrementalStore.h
+++ b/PFIncrementalStore/PFIncrementalStore.h
@@ -86,4 +86,102 @@ extern NSString * PFResourceIdentifierFromReferenceObject(id referenceObject);
                     withContext:(NSManagedObjectContext *)context
                           error:(NSError *__autoreleasing *)error;
 
+///--------------------
+/// @name Notifications
+///--------------------
+
+/**
+ Posted before an HTTP request operation corresponding to a fetch request starts.
+ The object is the managed object context of the request.
+ The notification `userInfo` contains the finished request operation, keyed at `PFIncrementalStoreRequestOperationKey`, as well as the associated persistent store request, if applicable, keyed at `PFIncrementalStorePersistentStoreRequestKey`.
+ */
+extern NSString * const PFIncrementalStoreContextWillFetchRemoteValues;
+
+/**
+ Posted after an HTTP request operation corresponding to a fetch request finishes.
+ The object is the managed object context of the request.
+ The notification `userInfo` contains the finished request operation, keyed at `PFIncrementalStoreRequestOperationKey`, as well as the associated persistent store request, if applicable, keyed at `PFIncrementalStorePersistentStoreRequestKey`.
+ */
+extern NSString * const PFIncrementalStoreContextDidFetchRemoteValues;
+
+//------------------------------------------------------------------------------
+
+/**
+ Posted before an HTTP request operation corresponding to a fetch request starts.
+ The object is the managed object context of the request.
+ The notification `userInfo` contains an array of request operations, keyed at `PFIncrementalStoreRequestOperationKey`, as well as the associated persistent store request, if applicable, keyed at `PFIncrementalStorePersistentStoreRequestKey`.
+ */
+extern NSString * const PFIncrementalStoreContextWillSaveRemoteValues;
+
+/**
+ Posted after an HTTP request operation corresponding to a fetch request finishes.
+ The object is the managed object context of the request.
+ The notification `userInfo` contains an array of request operations, keyed at `PFIncrementalStoreRequestOperationKey`, as well as the associated persistent store request, if applicable, keyed at `PFIncrementalStorePersistentStoreRequestKey`.
+ */
+extern NSString * const PFIncrementalStoreContextDidSaveRemoteValues;
+
+//------------------------------------------------------------------------------
+
+/**
+ Posted before an HTTP request operation corresponding to an attribute fault starts.
+ The object is the managed object context of the request.
+ The notification `userInfo` contains an array of request operations, keyed at `PFIncrementalStoreRequestOperationKey`, as well as the managed object ID of the faulting object, keyed at `PFIncrementalStoreFaultingObjectIDKey`.
+ */
+extern NSString * const PFIncrementalStoreContextWillFetchNewValuesForObject;
+
+/**
+ Posted after an HTTP request operation corresponding to an attribute fault finishes.
+ The object is the managed object context of the request.
+ The notification `userInfo` contains an array of request operations, keyed at `PFIncrementalStoreRequestOperationKey`, as well as the managed object ID of the faulting object, keyed at `PFIncrementalStoreFaultingObjectIDKey`.
+ */
+extern NSString * const PFIncrementalStoreContextDidFetchNewValuesForObject;
+
+//------------------------------------------------------------------------------
+
+/**
+ Posted before an HTTP request operation corresponding to an relationship fault starts.
+ The object is the managed object context of the request.
+ The notification `userInfo` contains an array of request operations, keyed at `PFIncrementalStoreRequestOperationKey`, as well as the faulting relationship, keyed at `PFIncrementalStoreFaultingRelationshipKey`, and the managed object ID of the faulting object, keyed at `PFIncrementalStoreFaultingObjectIDKey`.
+ 
+ */
+extern NSString * const PFIncrementalStoreContextWillFetchNewValuesForRelationship;
+
+/**
+ Posted after an HTTP request operation corresponding to a relationship fault finishes.
+ The object is the managed object context of the request.
+ The notification `userInfo` contains an array of request operations, keyed at `PFIncrementalStoreRequestOperationKey`, as well as the faulting relationship, keyed at `PFIncrementalStoreFaultingRelationshipKey`, and the managed object ID of the faulting object, keyed at `PFIncrementalStoreFaultingObjectIDKey`.
+ */
+extern NSString * const PFIncrementalStoreContextDidFetchNewValuesForRelationship;
+
+//------------------------------------------------------------------------------
+
+/**
+ A key in the `userInfo` dictionary in a `PFIncrementalStoreContextWillFetchRemoteValues` or `PFIncrementalStoreContextDidFetchRemoteValues` as well as `PFIncrementalStoreContextWillSaveRemoteValues` or `PFIncrementalStoreContextDidSaveRemoteValues` notifications.
+ The corresponding value is an `NSArray` of `AFHTTPRequestOperation` objects corresponding to the request operations triggered by the fetch or save changes request.
+ */
+extern NSString * const PFIncrementalStoreRequestOperationsKey;
+
+/**
+ A key in the `userInfo` dictionary in a `PFIncrementalStoreContextWillFetchRemoteValues` or `PFIncrementalStoreContextDidFetchRemoteValues` notification.
+ The corresponding value is an `NSArray` of `NSManagedObjectIDs` for the objects returned by the remote HTTP request for the associated fetch request.
+ */
+extern NSString * const PFIncrementalStoreFetchedObjectIDsKey;
+
+/**
+ A key in the `userInfo` dictionary in a `PFIncrementalStoreContextWillFetchNewValuesForObject` or `PFIncrementalStoreContextDidFetchNewValuesForObject` notification.
+ The corresponding value is an `NSManagedObjectID` for the faulting managed object.
+ */
+extern NSString * const PFIncrementalStoreFaultingObjectIDKey;
+
+/**
+ A key in the `userInfo` dictionary in a `PFIncrementalStoreContextWillFetchNewValuesForRelationship` or `PFIncrementalStoreContextDidFetchNewValuesForRelationship` notification.
+ The corresponding value is an `NSRelationshipDescription` for the faulting relationship.
+ */
+extern NSString * const PFIncrementalStoreFaultingRelationshipKey;
+
+/**
+ A key in the `userInfo` dictionary in a `PFIncrementalStoreContextWillFetchRemoteValues` or `PFIncrementalStoreContextDidFetchRemoteValues` notification.
+ The corresponding value is an `NSPersistentStoreRequest` object representing the associated fetch or save request. */
+extern NSString * const PFIncrementalStorePersistentStoreRequestKey;
+
 @end

--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -716,7 +716,6 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
         [backingObject setValue:object.updatedAt forKey:kPFIncrementalStoreLastModifiedAttributeName];
         [backingObject setValuesFromParseObject:object];
         
-        NSLog(@"%@",backingObject);
         if (!backingObjectID) {
             [context insertObject:managedObject];
         }

--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -43,6 +43,9 @@ NSString * const PFIncrementalStoreFaultingObjectIDKey = @"PFIncrementalStoreFau
 NSString * const PFIncrementalStoreFaultingRelationshipKey = @"PFIncrementalStoreFaultingRelationship";
 NSString * const PFIncrementalStorePersistentStoreRequestKey = @"PFIncrementalStorePersistentStoreRequest";
 
+#pragma mark - Block Definitions Methods
+
+typedef void (^PFInsertUpdateResponseBlock)(NSArray *managedObjects, NSArray *backingObjects);
 
 #pragma mark - Resource Identifier Methods
 
@@ -185,6 +188,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
                                 [context refreshObject:parentObject mergeChanges:YES];
                             }
                         }];
+                        
                         
                         [self notifyManagedObjectContext:context requestIsCompleted:YES forFetchRequest:fetchRequest fetchedObjectIDs:[managedObjects valueForKeyPath:@"objectID"]];
                     }];
@@ -674,8 +678,8 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
                     ofEntity:(NSEntityDescription *)entity
                  withContext:(NSManagedObjectContext *)context
                        error:(NSError *__autoreleasing *)error
-             completionBlock:(void (^)(NSArray *managedObjects, NSArray *backingObjects))completionBlock {
-    
+             completionBlock:(PFInsertUpdateResponseBlock)completionBlock {
+    return YES;
     if (!parseObjects) {
         return NO;
     }

--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -1,3 +1,4 @@
+
 // PFIncrementalStore.m
 //
 // Copyright (c) 2013 Scott BonAmi
@@ -108,6 +109,7 @@ inline NSString * PFResourceIdentifierFromReferenceObject(id referenceObject) {
 - (id)executeFetchRequest:(NSFetchRequest *)fetchRequest
               withContext:(NSManagedObjectContext *)context
                     error:(NSError *__autoreleasing *)error {
+    
     switch (fetchRequest.resultType) {
             
         case NSManagedObjectResultType: {
@@ -134,10 +136,10 @@ inline NSString * PFResourceIdentifierFromReferenceObject(id referenceObject) {
 }
 
 -(NSArray *)objectResultOfFetchRequest:(NSFetchRequest *)fetchRequest
-                         withContext:(NSManagedObjectContext *)context
-                               error:(NSError *__autoreleasing *)error {
     PFQuery *query = [PFQuery queryWithClassName:fetchRequest.entityName predicate:fetchRequest.predicate];
     NSMutableSet *fetchedObjects = [NSMutableSet set];
+                           withContext:(NSManagedObjectContext *)context
+                                 error:(NSError *__autoreleasing *)error {
     
     for (PFObject *object in [query findObjects]) {
         NSManagedObjectID *objectID = [self managedObjectIDForEntity:fetchRequest.entity withParseObjectId:object.objectId];
@@ -162,6 +164,7 @@ inline NSString * PFResourceIdentifierFromReferenceObject(id referenceObject) {
 -(NSUInteger)countResultOfFetchRequest:(NSFetchRequest *)fetchRequest
                            withContext:(NSManagedObjectContext *)context
                                  error:(NSError *__autoreleasing *)error {
+    
     return [[self objectResultOfFetchRequest:fetchRequest withContext:context error:error] count];
 }
 
@@ -344,7 +347,7 @@ inline NSString * PFResourceIdentifierFromReferenceObject(id referenceObject) {
 }
 
 - (NSManagedObjectID *)managedObjectIDForEntity:(NSEntityDescription *)entity
-                  withParseObjectId:(NSString *)resourceIdentifier {
+                              withParseObjectId:(NSString *)resourceIdentifier {
     if (!resourceIdentifier) {
         return nil;
     }

--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -207,7 +207,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
             return [self dictionaryResultOfFetchRequest:fetchRequest withContext:context error:error];
         }
         case NSCountResultType: {
-            return [NSNumber numberWithInteger:[self countResultOfFetchRequest:fetchRequest withContext:context error:error]];
+            return [self countResultOfFetchRequest:fetchRequest withContext:context error:error];
         }
     }
     
@@ -265,11 +265,12 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
     return [backingContext executeFetchRequest:backingFetchRequest error:error];
 }
 
--(NSUInteger)countResultOfFetchRequest:(NSFetchRequest *)fetchRequest
-                           withContext:(NSManagedObjectContext *)context
-                                 error:(NSError *__autoreleasing *)error {
+-(NSArray *)countResultOfFetchRequest:(NSFetchRequest *)fetchRequest
+                          withContext:(NSManagedObjectContext *)context
+                                error:(NSError *__autoreleasing *)error {
     
-    return [[self objectResultOfFetchRequest:fetchRequest withContext:context error:error] count];
+    int count = [[self objectResultOfFetchRequest:fetchRequest withContext:context error:error] count];
+    return @[[NSNumber numberWithInt:count]];
 }
 
 #pragma mark - Save Request methods

--- a/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
+++ b/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
@@ -6,6 +6,8 @@
 //
 //
 
+#import <Parse/Parse.h>
+
 #import "PFIncrementalStore.h"
 
 static NSString * const kPFIncrementalStoreErrorDomain = @"PFIncrementalStoreErrorDomain";
@@ -34,6 +36,13 @@ typedef void (^PFInsertUpdateResponseBlock)(NSArray *managedObjects, NSArray *ba
                        error:(NSError *__autoreleasing *)error
              completionBlock:(PFInsertUpdateResponseBlock)completionBlock;
 
+- (void)updateBackingObject:(NSManagedObject *)backingObject
+withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedObject;
+
+// Object ID Methods
+- (NSManagedObjectID *)managedObjectIDForBackingObjectForEntity:(NSEntityDescription *)entity
+                                              withParseObjectId:(NSString *)resourceIdentifier;
+
 // Notification Methods
 - (void)notifyManagedObjectContext:(NSManagedObjectContext *)context
                 requestIsCompleted:(BOOL)isCompleted
@@ -53,5 +62,19 @@ typedef void (^PFInsertUpdateResponseBlock)(NSArray *managedObjects, NSArray *ba
                 requestIsCompleted:(BOOL)isCompleted
                        forNewValuesForRelationship:(NSRelationshipDescription *)relationship
                                           forObjectWithID:(NSManagedObjectID *)objectID;
+
+@end
+
+@interface NSManagedObject (_PFIncrementalStore)
+
+@property (readwrite, nonatomic, copy, setter = pf_setResourceIdentifier:) NSString *pf_resourceIdentifier;
+
+- (void)setValuesFromParseObject:(PFObject *)parseObject;
+
+@end
+
+@interface PFObject (_PFIncrementalStore)
+
+- (void)setValuesFromManagedObject:(NSManagedObject *)managedObject;
 
 @end

--- a/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
+++ b/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
@@ -11,11 +11,47 @@
 static NSString * const kPFIncrementalStoreErrorDomain = @"PFIncrementalStoreErrorDomain";
 static NSString * const kPFIncrementalStoreUnimplementedMethodException = @"PFIncrementalStoreUnimplementedMethodException";
 
+static NSString * const kPFReferenceObjectPrefix = @"__pf_";
+static NSString * const kPFIncrementalStoreLastModifiedAttributeName = @"__pf_lastModified";
+static NSString * const kPFIncrementalStoreResourceIdentifierAttributeName = @"__pf_resourceIdentifier";
+
 inline NSString * PFReferenceObjectFromResourceIdentifier(NSString *resourceIdentifier);
 inline NSString * PFResourceIdentifierFromReferenceObject(id referenceObject);
+
+inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException(NSManagedObjectContext *managedObjectContext);
 
 @interface PFIncrementalStore ()
 
 - (NSManagedObjectContext *)backingManagedObjectContext;
+
+// Backing Methods
+
+typedef void (^PFInsertUpdateResponseBlock)(NSArray *managedObjects, NSArray *backingObjects);
+
+-(BOOL)insertOrUpdateObjects:(NSArray *)parseObjects
+                    ofEntity:(NSEntityDescription *)entity
+                 withContext:(NSManagedObjectContext *)context
+                       error:(NSError *__autoreleasing *)error
+             completionBlock:(PFInsertUpdateResponseBlock)completionBlock;
+
+// Notification Methods
+- (void)notifyManagedObjectContext:(NSManagedObjectContext *)context
+                requestIsCompleted:(BOOL)isCompleted
+                                   forFetchRequest:(NSFetchRequest *)fetchRequest
+                                                     fetchedObjectIDs:(NSArray *)fetchedObjectIDs;
+
+- (void)notifyManagedObjectContext:(NSManagedObjectContext *)context
+                requestIsCompleted:(BOOL)isCompleted
+                             forSaveChangesRequest:(NSSaveChangesRequest *)saveChangesRequest
+                                               changedObjectIDs:(NSArray *)changedObjectIDs;
+
+- (void)notifyManagedObjectContext:(NSManagedObjectContext *)context
+                requestIsCompleted:(BOOL)isCompleted
+                       forNewValuesForObjectWithID:(NSManagedObjectID *)objectID;
+
+- (void)notifyManagedObjectContext:(NSManagedObjectContext *)context
+                requestIsCompleted:(BOOL)isCompleted
+                       forNewValuesForRelationship:(NSRelationshipDescription *)relationship
+                                          forObjectWithID:(NSManagedObjectID *)objectID;
 
 @end

--- a/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
+++ b/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
@@ -1,0 +1,21 @@
+//
+//  PFIncrementalStore_PrivateMethods.h
+//  Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import "PFIncrementalStore.h"
+
+static NSString * const kPFIncrementalStoreErrorDomain = @"PFIncrementalStoreErrorDomain";
+static NSString * const kPFIncrementalStoreUnimplementedMethodException = @"PFIncrementalStoreUnimplementedMethodException";
+
+inline NSString * PFReferenceObjectFromResourceIdentifier(NSString *resourceIdentifier);
+inline NSString * PFResourceIdentifierFromReferenceObject(id referenceObject);
+
+@interface PFIncrementalStore ()
+
+- (NSManagedObjectContext *)backingManagedObjectContext;
+
+@end

--- a/Tests/Mock Objects/TestIncrementalStore.h
+++ b/Tests/Mock Objects/TestIncrementalStore.h
@@ -1,0 +1,14 @@
+//
+//  TestIncrementalStore.h
+//  Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import "PFIncrementalStore.h"
+#import "TestManagedObjectModel.h"
+
+@interface TestIncrementalStore : PFIncrementalStore
+
+@end

--- a/Tests/Mock Objects/TestIncrementalStore.m
+++ b/Tests/Mock Objects/TestIncrementalStore.m
@@ -1,0 +1,25 @@
+//
+//  TestIncrementalStore.m
+//  Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import "TestIncrementalStore.h"
+
+@implementation TestIncrementalStore
+
++ (void)initialize {
+    [NSPersistentStoreCoordinator registerStoreClass:self forStoreType:[self type]];
+}
+
++ (NSString *)type {
+    return NSStringFromClass(self);
+}
+
++ (NSManagedObjectModel *)model {
+    return [[TestManagedObjectModel alloc] init];
+}
+
+@end

--- a/Tests/Mock Objects/TestManagedObjectModel.h
+++ b/Tests/Mock Objects/TestManagedObjectModel.h
@@ -1,0 +1,13 @@
+//
+//  TestManagedObjectModel.h
+//  Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import <CoreData/CoreData.h>
+
+@interface TestManagedObjectModel : NSManagedObjectModel
+
+@end

--- a/Tests/Mock Objects/TestManagedObjectModel.m
+++ b/Tests/Mock Objects/TestManagedObjectModel.m
@@ -1,0 +1,31 @@
+//
+//  TestManagedObjectModel.m
+//  Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import "TestManagedObjectModel.h"
+
+@implementation TestManagedObjectModel
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        
+        [self setEntities:@[
+                            [TestManagedObjectModel entityDescriptionForEntityWithName:@"TestEntity"]
+                            ]];
+    }
+    return self;
+}
+
++(NSEntityDescription *)entityDescriptionForEntityWithName:(NSString *)entityName {
+    NSEntityDescription *entity = [[NSEntityDescription alloc] init];
+    [entity setName:entityName];
+    return entity;
+}
+
+@end

--- a/Tests/OS X Test/OS X Test-Prefix.pch
+++ b/Tests/OS X Test/OS X Test-Prefix.pch
@@ -6,4 +6,6 @@
 
 #ifdef __OBJC__
     #import <Cocoa/Cocoa.h>
+
+    #import <PFIncrementalStore/PFIncrementalStore.h>
 #endif

--- a/Tests/OS X Test/OS_X_Test.m
+++ b/Tests/OS X Test/OS_X_Test.m
@@ -6,24 +6,8 @@
 //
 //
 
-#import <XCTest/XCTest.h>
+#import <Kiwi/Kiwi.h>
 
-@interface OS_X_Test : XCTestCase
+SPEC_BEGIN(OSXSpecificTests)
 
-@end
-
-@implementation OS_X_Test
-
-- (void)setUp
-{
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown
-{
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
-@end
+SPEC_END

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -3,6 +3,7 @@ workspace '../PFIncrementalStore'
 inhibit_all_warnings!
 
 def import_pods
+  pod 'Kiwi/XCTest'
   pod 'PFIncrementalStore', :path => '../'
 end
 

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,5 +1,10 @@
 PODS:
   - Facebook-iOS-SDK (3.10.0)
+  - Kiwi/ARC (2.2.3)
+  - Kiwi/NonARC (2.2.3)
+  - Kiwi/XCTest (2.2.3):
+    - Kiwi/ARC
+    - Kiwi/NonARC
   - Parse-iOS-SDK (1.2.17):
     - Facebook-iOS-SDK (~> 3.7)
   - Parse-OSX-SDK (1.2.17)
@@ -8,6 +13,7 @@ PODS:
     - Parse-OSX-SDK
 
 DEPENDENCIES:
+  - Kiwi/XCTest
   - PFIncrementalStore (from `../`)
 
 EXTERNAL SOURCES:
@@ -16,6 +22,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Facebook-iOS-SDK: ef402579aeb30cf0c4a6370fb0a927e3dc3059e5
+  Kiwi: 04c51e880831d291748ec702d42c4101f7eb95c9
   Parse-iOS-SDK: f57fc3a7b80c7135d5acdc55a0fbc3ab2d1d5027
   Parse-OSX-SDK: 3640c1f1f60cc6a3ae0e01757bc809a3a4468827
   PFIncrementalStore: 943720374826cb62a71b1cb90416e8054dc0f347

--- a/Tests/Shared Tests/FetchRequest_Tests.m
+++ b/Tests/Shared Tests/FetchRequest_Tests.m
@@ -1,0 +1,170 @@
+//
+//  FetchRequest_Tests.m
+//  Shared Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import <Kiwi/Kiwi.h>
+#import "PFIncrementalStore_PrivateMethods.h"
+
+#import <Parse/Parse.h>
+
+#import "TestIncrementalStore.h"
+#import "TestManagedObjectModel.h"
+
+NSFetchRequest * FetchRequestWithRequestResultType(NSFetchRequestResultType resultType) {
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:@"TestEntity"];
+    [fetchRequest setResultType:resultType];
+    return fetchRequest;
+}
+
+SPEC_BEGIN(FetchRequest_Tests)
+
+__block NSFetchRequest *fetchRequest = nil;
+__block TestIncrementalStore *testIncrementalStore = nil;
+__block NSManagedObjectContext *testManagedObjectContext = nil;
+__block NSManagedObjectContext *testBackingManagedObjectContext = nil;
+
+beforeEach(^{
+    // Create Persistent Store Coordinator so that we may create a Test Incremental Store
+    NSPersistentStoreCoordinator *persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[TestIncrementalStore model]];
+    
+    // Create Test Incremental Store
+    testIncrementalStore = (TestIncrementalStore *)[persistentStoreCoordinator addPersistentStoreWithType:[TestIncrementalStore type]
+                                                                                            configuration:nil URL:nil options:nil error:nil];
+    
+    // Create MOC for testing
+    testManagedObjectContext = [[NSManagedObjectContext alloc] init];
+    [testManagedObjectContext setPersistentStoreCoordinator:persistentStoreCoordinator];
+    
+    // Create Backing Persistent Store Coordinator for the Test Incremental Store's Backing MOC
+    [testIncrementalStore.backingPersistentStoreCoordinator addPersistentStoreWithType:NSInMemoryStoreType configuration:nil URL:nil options:nil error:nil];
+    
+    // Create Backing MOC for testing
+    testBackingManagedObjectContext = [[NSManagedObjectContext alloc] init];
+    [testBackingManagedObjectContext setPersistentStoreCoordinator:testIncrementalStore.backingPersistentStoreCoordinator];
+});
+
+describe(@"executeRequest:withContext:error:", ^{
+    it(@"should call executeFetchRequest:withContext:error: if the request type is NSFetchRequestType", ^{
+        fetchRequest = FetchRequestWithRequestResultType(NSManagedObjectResultType);
+        
+        [[testIncrementalStore should] receive:@selector(executeFetchRequest:withContext:error:) withArguments:fetchRequest, testManagedObjectContext, nil];
+        
+        [testIncrementalStore executeRequest:fetchRequest withContext:testManagedObjectContext error:nil];
+    });
+});
+
+describe(@"executeFetchRequest:withContext:error:", ^{
+    beforeEach(^{
+        // Stub Test Incremental Store's Backing MOC
+        [testIncrementalStore stub:@selector(backingManagedObjectContext) andReturn:testBackingManagedObjectContext];
+        
+        // Stub Parse
+        PFQuery *query = [PFQuery mock];
+        [PFQuery stub:@selector(queryWithClassName:) andReturn:query withArguments:@"TestEntity"];
+        [query stub:@selector(findObjectsInBackgroundWithBlock:)];
+    });
+    
+    context(@"when the request type is NSManagedObjectResultType", ^{
+        beforeEach(^{
+            fetchRequest = FetchRequestWithRequestResultType(NSManagedObjectResultType);
+            
+            NSManagedObject *testEntity = [NSManagedObject mockWithName:@"TestEntity"];
+            [testBackingManagedObjectContext stub:@selector(executeFetchRequest:error:) andReturn:@[testEntity]];
+        });
+        
+        context(@"-- Communication with Parse --", ^{
+            context(@"when the parse query fails", ^{
+                pending(@"should notify user that sync is completed with no objects returned", ^{});
+            });
+            
+            context(@"when the parse query succeeds", ^{
+                pending(@"should insert new response objects into backing store", ^{});
+                
+                pending(@"should update existing response objects in backing store", ^{});
+                
+                pending(@"should notify user that sync is completed with objects returned", ^{});
+            });
+        });
+        
+        context(@"-- Communication with Backing Store --", ^{
+            pending(@"should return an array of NSManagedObjects", ^{
+                id output = [testIncrementalStore executeFetchRequest:fetchRequest withContext:testManagedObjectContext error:nil];
+                [[output should] beKindOfClass:[NSArray class]];
+                [[[output objectAtIndex:0] should] beKindOfClass:[NSManagedObject class]];
+            });
+            
+            pending(@"returned NSManagedObjects should be faulted", ^{
+                id output = [testIncrementalStore executeFetchRequest:fetchRequest withContext:testManagedObjectContext error:nil];
+                [[output should] beKindOfClass:[NSArray class]];
+                NSManagedObject *firstObject = [output objectAtIndex:0];
+                [[theValue([firstObject isFault]) should] beTrue];
+            });
+        });
+    });
+    
+    context(@"when the request type is NSManagedObjectIDResultType", ^{
+        beforeEach(^{
+            fetchRequest = FetchRequestWithRequestResultType(NSManagedObjectIDResultType);
+            
+            NSManagedObject *testEntity = [NSManagedObject mockWithName:@"TestEntity"];
+            [testBackingManagedObjectContext stub:@selector(executeFetchRequest:error:) andReturn:@[testEntity]];
+        });
+        
+        pending(@"should return an array of NSManagedObjectIDs", ^{
+            id output = [testIncrementalStore executeFetchRequest:fetchRequest withContext:testManagedObjectContext error:nil];
+            [[output should] beKindOfClass:[NSArray class]];
+            [[[output objectAtIndex:0] should] beKindOfClass:[NSManagedObjectID class]];
+        });
+    });
+    
+    context(@"when the request type is NSDictionaryResultType", ^{
+        beforeEach(^{
+            fetchRequest = FetchRequestWithRequestResultType(NSDictionaryResultType);
+            
+            NSManagedObject *testEntity = [NSManagedObject mockWithName:@"TestEntity"];
+            [testBackingManagedObjectContext stub:@selector(executeFetchRequest:error:) andReturn:@[testEntity]];
+        });
+        
+        pending(@"should return an array of NSDictionaries", ^{
+            id output = [testIncrementalStore executeFetchRequest:fetchRequest withContext:testManagedObjectContext error:nil];
+            [[output should] beKindOfClass:[NSArray class]];
+            [[[output objectAtIndex:0] should] beKindOfClass:[NSDictionary class]];
+        });
+    });
+    
+    context(@"when the request type is NSCountResultType", ^{
+        beforeEach(^{
+            fetchRequest = FetchRequestWithRequestResultType(NSCountResultType);
+            
+            NSManagedObject *testEntity = [NSManagedObject mockWithName:@"TestEntity"];
+            [testBackingManagedObjectContext stub:@selector(executeFetchRequest:error:) andReturn:@[testEntity]];
+        });
+        
+        pending(@"should return an array with one NSNumber value", ^{
+            id output = [testIncrementalStore executeFetchRequest:fetchRequest withContext:testManagedObjectContext error:nil];
+            [[output should] beKindOfClass:[NSArray class]];
+            [[theValue([output count]) should] equal:theValue(1)];
+            [[[output objectAtIndex:0] should] beKindOfClass:[NSNumber class]];
+        });
+        
+        pending(@"returned NSNumber should equal the number of objects returned in the query", ^{
+            id output = [testIncrementalStore executeFetchRequest:fetchRequest withContext:testManagedObjectContext error:nil];
+            [[output should] beKindOfClass:[NSArray class]];
+            NSNumber *firstObject = [output objectAtIndex:0];
+            [[firstObject should] equal:[NSNumber numberWithInt:2]];
+        });
+    });
+    
+    context(@"when the request type is invalid", ^{
+        it(@"should raise an exception", ^{
+            NSFetchRequest *invalidFetchRequest = FetchRequestWithRequestResultType(-1);
+            [[theBlock(^{ [testManagedObjectContext executeFetchRequest:invalidFetchRequest error:nil]; }) shouldNot] raiseWithName:kPFIncrementalStoreUnimplementedMethodException];
+        });
+    });
+});
+
+SPEC_END

--- a/Tests/Shared Tests/RequiredMethod_Tests.m
+++ b/Tests/Shared Tests/RequiredMethod_Tests.m
@@ -1,0 +1,44 @@
+//
+//  RequiredMethod_Tests.m
+//  Shared Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import <Kiwi/Kiwi.h>
+#import "PFIncrementalStore_PrivateMethods.h"
+
+#import "TestIncrementalStore.h"
+
+SPEC_BEGIN(RequiredMethod_Tests)
+
+describe(@"+type", ^{
+    context(@"when a subclass has not implemented the method", ^{
+        it(@"should raise an exception", ^{
+            [[theBlock(^{ [PFIncrementalStore type]; }) should] raiseWithName:kPFIncrementalStoreUnimplementedMethodException];
+        });
+    });
+    
+    context(@"when a subclass has implemented the method", ^{
+        it(@"should not raise an exception", ^{
+            [[theBlock(^{ [TestIncrementalStore type]; }) shouldNot] raiseWithName:kPFIncrementalStoreUnimplementedMethodException];
+        });
+    });
+});
+
+describe(@"+model", ^{
+    context(@"when a subclass has not implemented the method", ^{
+        it(@"should raise an exception", ^{
+            [[theBlock(^{ [PFIncrementalStore model]; }) should] raiseWithName:kPFIncrementalStoreUnimplementedMethodException];
+        });
+    });
+    
+    context(@"when a subclass has implemented the method", ^{
+        it(@"should not raise an exception", ^{
+            [[theBlock(^{ [TestIncrementalStore model]; }) shouldNot] raiseWithName:kPFIncrementalStoreUnimplementedMethodException];
+        });
+    });
+});
+
+SPEC_END

--- a/Tests/Shared Tests/ResourceIdentifier_Tests.m
+++ b/Tests/Shared Tests/ResourceIdentifier_Tests.m
@@ -1,0 +1,53 @@
+//
+//  ResourceIdentifier_Tests.m
+//  Shared Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import <Kiwi/Kiwi.h>
+#import "PFIncrementalStore_PrivateMethods.h"
+
+SPEC_BEGIN(ResourceIdentifier_Tests)
+
+describe(@"PFReferenceObjectFromResourceIdentifier", ^{
+    context(@"with an invalid argument", ^{
+        it(@"should return nil", ^{
+            [[PFReferenceObjectFromResourceIdentifier(nil) should] beNil];
+        });
+    });
+    
+    context(@"with a valid argument", ^{
+        it(@"should return a reference object that begins with kPFReferenceObjectPrefix", ^{
+            NSString *resourceIdentifier = @"resourceIdentifier";
+            [[PFReferenceObjectFromResourceIdentifier(resourceIdentifier) should] equal:[NSString stringWithFormat:@"__pf_%@",resourceIdentifier]];
+        });
+    });
+});
+
+describe(@"PFResourceIdentifierFromReferenceObject", ^{
+    context(@"with an invalid argument", ^{
+        it(@"should return nil", ^{
+            [[PFResourceIdentifierFromReferenceObject(nil) should] beNil];
+        });
+    });
+    
+    context(@"when an argument is passed", ^{
+        context(@"and the argument starts with kPFReferenceObjectPrefix", ^{
+            it(@"should return a resource identifier without the kPFReferenceObjectPrefix", ^{
+                NSString *resourceIdentifier = @"resourceIdentifier";
+                NSString *referenceObject = [NSString stringWithFormat:@"__pf_%@",resourceIdentifier];
+                [[PFResourceIdentifierFromReferenceObject(referenceObject) should] equal:resourceIdentifier];
+            });
+        });
+        context(@"and the argument does not start with kPFReferenceObjectPrefix", ^{
+            it(@"should return a resource identifier equal to the argument", ^{
+                NSString *referenceObject = @"referenceObject";
+                [[PFResourceIdentifierFromReferenceObject(referenceObject) should] equal:referenceObject];
+            });
+        });
+    });
+});
+
+SPEC_END

--- a/Tests/Shared Tests/SaveRequest_Tests.m
+++ b/Tests/Shared Tests/SaveRequest_Tests.m
@@ -306,7 +306,7 @@ describe(@"executeSaveChangesRequest:withContext:error:", ^{
                 
                 KWCaptureSpy *spy = [testQuery captureArgument:@selector(getObjectInBackgroundWithId:block:) atIndex:1];
                 [testIncrementalStore executeSaveChangesRequest:saveChangesRequest withContext:testManagedObjectContext error:nil];
-
+                
                 fetchBlockToRun = spy.argument;
             });
             
@@ -386,17 +386,140 @@ describe(@"executeSaveChangesRequest:withContext:error:", ^{
     });
     
     context(@"with deleted objects", ^{
-        context(@"when the parse query fails", ^{
-            pending(@"should notify user that save is completed while sending no ids", ^{});
+        __block PFQuery *testQuery = nil;
+        __block NSManagedObjectID *testManagedObjectID = nil;
+        
+        beforeEach(^{
+            [saveChangesRequest stub:@selector(deletedObjects) andReturn:@[testEntity]];
+            
+            testManagedObjectID = [NSManagedObjectID nullMock];
+            
+            // Stub Parse
+            testQuery = [PFQuery mock];
+            [PFQuery stub:@selector(queryWithClassName:) andReturn:testQuery withArguments:testEntityDescription.name];
+            [testQuery stub:@selector(getObjectInBackgroundWithId:block:) andReturn:nil];
         });
         
-        context(@"when the parse query succeeds", ^{
-            pending(@"should insert new objects into backing store", ^{});
+        it(@"should fetch backing object ID from deleted object's resource identifier", ^{
+            [testEntity stub:@selector(objectID) andReturn:testManagedObjectID];
+            [testEntity stub:@selector(pf_resourceIdentifier) andReturn:@"TestParseObjectID"];
             
-            pending(@"should notify user that save is completed while sending object ids", ^{});
+            [testIncrementalStore stub:@selector(referenceObjectForObjectID:) andReturn:@"TestParseObjectID" withArguments:testManagedObjectID];
+            
+            [[testIncrementalStore should] receive:@selector(managedObjectIDForBackingObjectForEntity:withParseObjectId:) andReturn:nil withArguments:testEntityDescription, @"TestParseObjectID"];
+            
+            [testIncrementalStore executeSaveChangesRequest:saveChangesRequest withContext:testManagedObjectContext error:nil];
+        });
+        
+        it(@"should query parse for the object by it's parse object ID", ^{
+            [testEntity stub:@selector(objectID) andReturn:testManagedObjectID];
+            [testEntity stub:@selector(pf_resourceIdentifier) andReturn:@"TestParseObjectID"];
+            [testIncrementalStore stub:@selector(referenceObjectForObjectID:) andReturn:@"TestParseObjectID" withArguments:testManagedObjectID];
+            [testIncrementalStore stub:@selector(managedObjectIDForBackingObjectForEntity:withParseObjectId:) andReturn:testManagedObjectID];
+            
+            [[testQuery should] receive:@selector(getObjectInBackgroundWithId:block:) andReturn:nil withArguments:@"TestParseObjectID", any()];
+            
+            [testIncrementalStore executeSaveChangesRequest:saveChangesRequest withContext:testManagedObjectContext error:nil];
+        });
+        
+        it(@"should notify user that save is started for deleted object(s)", ^{
+            [testEntity stub:@selector(objectID) andReturn:testManagedObjectID];
+            [testEntity stub:@selector(pf_resourceIdentifier) andReturn:@"TestParseObjectID"];
+            [testIncrementalStore stub:@selector(referenceObjectForObjectID:) andReturn:@"TestParseObjectID" withArguments:testManagedObjectID];
+            [testIncrementalStore stub:@selector(managedObjectIDForBackingObjectForEntity:withParseObjectId:) andReturn:testManagedObjectID];
+            [testQuery stub:@selector(getObjectInBackgroundWithId:block:)];
+            
+            [[testIncrementalStore should] receive:@selector(notifyManagedObjectContext:requestIsCompleted:forSaveChangesRequest:changedObjectIDs:) withArguments:testManagedObjectContext, theValue(NO), any(), @[testManagedObjectID]];
+            
+            [testIncrementalStore executeSaveChangesRequest:saveChangesRequest withContext:testManagedObjectContext error:nil];
+        });
+        
+        context(@"-- Communication with Parse --", ^{
+            __block PFObjectResultBlock fetchBlockToRun = nil;
+            
+            beforeEach(^{
+                [testEntity stub:@selector(objectID) andReturn:testManagedObjectID];
+                [testEntity stub:@selector(pf_resourceIdentifier) andReturn:@"TestParseObjectID"];
+                [testIncrementalStore stub:@selector(referenceObjectForObjectID:) andReturn:@"TestParseObjectID" withArguments:testManagedObjectID];
+                [testIncrementalStore stub:@selector(managedObjectIDForBackingObjectForEntity:withParseObjectId:) andReturn:testManagedObjectID];
+                
+                KWCaptureSpy *spy = [testQuery captureArgument:@selector(getObjectInBackgroundWithId:block:) atIndex:1];
+                [testIncrementalStore executeSaveChangesRequest:saveChangesRequest withContext:testManagedObjectContext error:nil];
+                
+                fetchBlockToRun = spy.argument;
+            });
+            
+            context(@"for the object fetch result", ^{
+                context(@"when the parse fetch query fails", ^{
+                    it(@"should notify user that delete failed while sending ids", ^{
+                        [[testIncrementalStore should] receive:@selector(notifyManagedObjectContext:requestIsCompleted:forSaveChangesRequest:changedObjectIDs:) withArguments:testManagedObjectContext, theValue(YES), any(), @[testManagedObjectID]];
+                        
+                        fetchBlockToRun(nil, [NSError errorWithDomain:@"" code:0 userInfo:nil]);
+                    });
+                });
+                
+                context(@"when the parse fetch query succeeds", ^{
+                    it(@"should delete the parse object", ^{
+                        [[testObject should] receive:@selector(deleteInBackgroundWithBlock:)];
+                        
+                        fetchBlockToRun(testObject, nil);
+                    });
+                    
+                    context(@"-- Communication with Parse --", ^{
+                        __block PFBooleanResultBlock deleteBlockToRun = nil;
+                        
+                        beforeEach(^{
+                            KWCaptureSpy *spy = [testObject captureArgument:@selector(deleteInBackgroundWithBlock:) atIndex:0];
+                            fetchBlockToRun(testObject, nil);
+                            
+                            deleteBlockToRun = spy.argument;
+                        });
+                        
+                        context(@"when the parse save fails", ^{
+                            it(@"should notify user that delete is completed while sending ids", ^{
+                                [[testIncrementalStore should] receive:@selector(notifyManagedObjectContext:requestIsCompleted:forSaveChangesRequest:changedObjectIDs:) withArguments:testManagedObjectContext, theValue(YES), any(), @[testManagedObjectID]];
+                                
+                                deleteBlockToRun(NO, [NSError errorWithDomain:@"" code:0 userInfo:nil]);
+                            });
+                        });
+                        
+                        context(@"when the parse delete succeeds", ^{
+                            __block NSManagedObject *testBackingObject = nil;
+                            
+                            beforeEach(^{
+                                testBackingObject = [NSManagedObject nullMock];
+                                
+                                [testObject stub:@selector(objectId) andReturn:@"TestParseObjectID"];
+                            });
+                            
+                            it(@"should fetch backing object from backing MOC", ^{
+                                [[testBackingManagedObjectContext should] receive:@selector(existingObjectWithID:error:) andReturn:testBackingObject withArguments:testManagedObjectID, any()];
+                                
+                                deleteBlockToRun(YES, nil);
+                            });
+                            
+                            it(@"should remove the deleted object from the backing MOC and save", ^{
+                                [testBackingManagedObjectContext stub:@selector(existingObjectWithID:error:) andReturn:testBackingObject withArguments:testManagedObjectID, any()];
+                                
+                                [[testBackingManagedObjectContext should] receive:@selector(deleteObject:) withArguments:testBackingObject, theValue(YES)];
+                                [[testBackingManagedObjectContext should] receive:@selector(save:)];
+                                
+                                deleteBlockToRun(YES, nil);
+                            });
+                            
+                            it(@"should notify user that delete is completed while sending object ids", ^{
+                                [testBackingManagedObjectContext stub:@selector(existingObjectWithID:error:) andReturn:testBackingObject withArguments:testManagedObjectID, any()];
+                                
+                                [[testIncrementalStore should] receive:@selector(notifyManagedObjectContext:requestIsCompleted:forSaveChangesRequest:changedObjectIDs:) withArguments:testManagedObjectContext, theValue(YES), any(), @[testManagedObjectID]];
+                                
+                                deleteBlockToRun(YES, nil);
+                            });
+                        });
+                    });
+                });
+            });
         });
     });
 });
-
 
 SPEC_END

--- a/Tests/Shared Tests/SaveRequest_Tests.m
+++ b/Tests/Shared Tests/SaveRequest_Tests.m
@@ -97,6 +97,7 @@ describe(@"executeSaveChangesRequest:withContext:error:", ^{
         
         context(@"-- Communication with Parse --", ^{
             __block PFBooleanResultBlock blockToRun = nil;
+            
             beforeEach(^{
                 KWCaptureSpy *spy = [testObject captureArgument:@selector(saveInBackgroundWithBlock:) atIndex:0];
                 [testIncrementalStore executeSaveChangesRequest:saveChangesRequest withContext:testManagedObjectContext error:nil];
@@ -104,7 +105,7 @@ describe(@"executeSaveChangesRequest:withContext:error:", ^{
                 blockToRun = spy.argument;
             });
             
-            it(@"should notify user that save is completed while sending nserted object ids", ^{
+            it(@"should notify user that save is completed while sending inserted object ids", ^{
                 [[testIncrementalStore should] receive:@selector(notifyManagedObjectContext:requestIsCompleted:forSaveChangesRequest:changedObjectIDs:) withArguments:testManagedObjectContext, theValue(YES), any(), @[@"TestEntityObjectID"]];
                 
                 blockToRun(NO, [NSError errorWithDomain:@"" code:0 userInfo:nil]);

--- a/Tests/Shared Tests/SaveRequest_Tests.m
+++ b/Tests/Shared Tests/SaveRequest_Tests.m
@@ -1,0 +1,92 @@
+//
+//  SaveRequest_Tests.m
+//  Shared Tests
+//
+//  Created by Scott BonAmi on 12/17/13.
+//
+//
+
+#import <Kiwi/Kiwi.h>
+#import "PFIncrementalStore_PrivateMethods.h"
+
+#import <Parse/Parse.h>
+
+#import "TestIncrementalStore.h"
+#import "TestManagedObjectModel.h"
+
+SPEC_BEGIN(SaveRequest_Tests)
+__block NSSaveChangesRequest *saveChangesRequest = nil;
+__block TestIncrementalStore *testIncrementalStore = nil;
+__block NSManagedObjectContext *testManagedObjectContext = nil;
+__block NSManagedObjectContext *testBackingManagedObjectContext = nil;
+
+beforeEach(^{
+    // Create Persistent Store Coordinator so that we may create a Test Incremental Store
+    NSPersistentStoreCoordinator *persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[TestIncrementalStore model]];
+    
+    // Create Test Incremental Store
+    testIncrementalStore = (TestIncrementalStore *)[persistentStoreCoordinator addPersistentStoreWithType:[TestIncrementalStore type]
+                                                                                            configuration:nil URL:nil options:nil error:nil];
+    
+    // Create MOC for testing
+    testManagedObjectContext = [[NSManagedObjectContext alloc] init];
+    [testManagedObjectContext setPersistentStoreCoordinator:persistentStoreCoordinator];
+    
+    // Create Backing Persistent Store Coordinator for the Test Incremental Store's Backing MOC
+    [testIncrementalStore.backingPersistentStoreCoordinator addPersistentStoreWithType:NSInMemoryStoreType configuration:nil URL:nil options:nil error:nil];
+    
+    // Create Backing MOC for testing
+    testBackingManagedObjectContext = [[NSManagedObjectContext alloc] init];
+    [testBackingManagedObjectContext setPersistentStoreCoordinator:testIncrementalStore.backingPersistentStoreCoordinator];
+    
+    saveChangesRequest = [[NSSaveChangesRequest alloc] init];
+});
+
+describe(@"executeRequest:withContext:error:", ^{
+    it(@"should call executeSaveChangesRequest:withContext:error: if the request type is NSFetchRequestType", ^{
+        [[testIncrementalStore should] receive:@selector(executeSaveChangesRequest:withContext:error:) withArguments:saveChangesRequest, testManagedObjectContext, nil];
+        
+        [testIncrementalStore executeRequest:saveChangesRequest withContext:testManagedObjectContext error:nil];
+    });
+});
+
+describe(@"executeSaveChangesRequest:withContext:error:", ^{
+    context(@"with inserted objects", ^{
+        context(@"when the parse query fails", ^{
+            pending(@"should notify user that save is completed while sending no ids", ^{});
+        });
+        
+        context(@"when the parse query succeeds", ^{
+            pending(@"should insert new objects into backing store", ^{});
+            
+            pending(@"should notify user that save is completed while sending object ids", ^{});
+        });
+    });
+    
+    context(@"with updated objects", ^{
+        context(@"when the parse query fails", ^{
+            pending(@"should notify user that save is completed while sending no ids", ^{});
+        });
+        
+        context(@"when the parse query succeeds", ^{
+            pending(@"should insert new objects into backing store", ^{});
+            
+            pending(@"should notify user that save is completed while sending object ids", ^{});
+        });
+    });
+    
+    context(@"with deleted objects", ^{
+        context(@"when the parse query fails", ^{
+            pending(@"should notify user that save is completed while sending no ids", ^{});
+        });
+        
+        context(@"when the parse query succeeds", ^{
+            pending(@"should insert new objects into backing store", ^{});
+            
+            pending(@"should notify user that save is completed while sending object ids", ^{});
+        });
+    });
+});
+
+
+SPEC_END

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		96C812BC1867D58E004B064E /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 962407861866CAAB00520783 /* ResourceIdentifier_Tests.m */; };
 		96C812BD1867D598004B064E /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
 		96C812BE1867D598004B064E /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
+		96C812BF1867D855004B064E /* SaveRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 962407871866CAAB00520783 /* SaveRequest_Tests.m */; };
+		96C812C01867D856004B064E /* SaveRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 962407871866CAAB00520783 /* SaveRequest_Tests.m */; };
 		A5FC87A080E44629BA8786E0 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C0140CE70AB4E6EA97A5A2F /* libPods-osx.a */; };
 		B8EFD6E709E1404693BD3FA9 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E84EF8B0347F4737BFABC2EC /* libPods-ios.a */; };
 /* End PBXBuildFile section */
@@ -335,6 +337,7 @@
 				96C812BB1867D58D004B064E /* ResourceIdentifier_Tests.m in Sources */,
 				96C812BD1867D598004B064E /* RequiredMethod_Tests.m in Sources */,
 				963F1E9B18582B77009C50DF /* iOS_Test.m in Sources */,
+				96C812BF1867D855004B064E /* SaveRequest_Tests.m in Sources */,
 				9622F1081861416900020D4C /* TestManagedObjectModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -347,6 +350,7 @@
 				96C812BC1867D58E004B064E /* ResourceIdentifier_Tests.m in Sources */,
 				966F86D118600D3B00178A45 /* FetchRequest_Tests.m in Sources */,
 				96C812BE1867D598004B064E /* RequiredMethod_Tests.m in Sources */,
+				96C812C01867D856004B064E /* SaveRequest_Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -17,13 +17,12 @@
 		963F1EA518582B89009C50DF /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 963F1E8E18582B77009C50DF /* XCTest.framework */; };
 		963F1EAB18582B89009C50DF /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 963F1EA918582B89009C50DF /* InfoPlist.strings */; };
 		963F1EAD18582B89009C50DF /* OS_X_Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 963F1EAC18582B89009C50DF /* OS_X_Test.m */; };
-		966F86C3185FF8FE00178A45 /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96EE40E7185EB27B005887CC /* ResourceIdentifier_Tests.m */; };
-		966F86CC18600B0500178A45 /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
 		966F86CE18600D0900178A45 /* FetchRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CD18600D0900178A45 /* FetchRequest_Tests.m */; };
-		966F86D018600D3600178A45 /* SaveRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CF18600D3600178A45 /* SaveRequest_Tests.m */; };
 		966F86D118600D3B00178A45 /* FetchRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CD18600D0900178A45 /* FetchRequest_Tests.m */; };
-		966F86D218600D3F00178A45 /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
-		96EE40E8185EB27B005887CC /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96EE40E7185EB27B005887CC /* ResourceIdentifier_Tests.m */; };
+		96C812BB1867D58D004B064E /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 962407861866CAAB00520783 /* ResourceIdentifier_Tests.m */; };
+		96C812BC1867D58E004B064E /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 962407861866CAAB00520783 /* ResourceIdentifier_Tests.m */; };
+		96C812BD1867D598004B064E /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
+		96C812BE1867D598004B064E /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
 		A5FC87A080E44629BA8786E0 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C0140CE70AB4E6EA97A5A2F /* libPods-osx.a */; };
 		B8EFD6E709E1404693BD3FA9 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E84EF8B0347F4737BFABC2EC /* libPods-ios.a */; };
 /* End PBXBuildFile section */
@@ -37,6 +36,8 @@
 		9622F1061861416900020D4C /* TestManagedObjectModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestManagedObjectModel.h; path = "Mock Objects/TestManagedObjectModel.h"; sourceTree = "<group>"; };
 		9622F1071861416900020D4C /* TestManagedObjectModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestManagedObjectModel.m; path = "Mock Objects/TestManagedObjectModel.m"; sourceTree = "<group>"; };
 		9622F1091861500B00020D4C /* PFIncrementalStore_PrivateMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PFIncrementalStore_PrivateMethods.h; path = "Mock Objects/PFIncrementalStore_PrivateMethods.h"; sourceTree = "<group>"; };
+		962407861866CAAB00520783 /* ResourceIdentifier_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ResourceIdentifier_Tests.m; path = "Shared Tests/ResourceIdentifier_Tests.m"; sourceTree = "<group>"; };
+		962407871866CAAB00520783 /* SaveRequest_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SaveRequest_Tests.m; path = "Shared Tests/SaveRequest_Tests.m"; sourceTree = "<group>"; };
 		963F1E8B18582B77009C50DF /* iOS Test.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Test.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		963F1E8E18582B77009C50DF /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		963F1E9018582B77009C50DF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -52,8 +53,6 @@
 		963F1EAE18582B89009C50DF /* OS X Test-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OS X Test-Prefix.pch"; sourceTree = "<group>"; };
 		966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RequiredMethod_Tests.m; path = "Shared Tests/RequiredMethod_Tests.m"; sourceTree = "<group>"; };
 		966F86CD18600D0900178A45 /* FetchRequest_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FetchRequest_Tests.m; path = "Shared Tests/FetchRequest_Tests.m"; sourceTree = "<group>"; };
-		966F86CF18600D3600178A45 /* SaveRequest_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SaveRequest_Tests.m; path = "Shared Tests/SaveRequest_Tests.m"; sourceTree = "<group>"; };
-		96EE40E7185EB27B005887CC /* ResourceIdentifier_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ResourceIdentifier_Tests.m; path = "Shared Tests/ResourceIdentifier_Tests.m"; sourceTree = "<group>"; };
 		E84EF8B0347F4737BFABC2EC /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -169,10 +168,10 @@
 		96EE40E6185EB0C2005887CC /* Shared Tests */ = {
 			isa = PBXGroup;
 			children = (
-				96EE40E7185EB27B005887CC /* ResourceIdentifier_Tests.m */,
+				962407861866CAAB00520783 /* ResourceIdentifier_Tests.m */,
 				966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */,
 				966F86CD18600D0900178A45 /* FetchRequest_Tests.m */,
-				966F86CF18600D3600178A45 /* SaveRequest_Tests.m */,
+				962407871866CAAB00520783 /* SaveRequest_Tests.m */,
 			);
 			name = "Shared Tests";
 			sourceTree = "<group>";
@@ -332,11 +331,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				966F86CE18600D0900178A45 /* FetchRequest_Tests.m in Sources */,
-				96EE40E8185EB27B005887CC /* ResourceIdentifier_Tests.m in Sources */,
 				9622F1051861402E00020D4C /* TestIncrementalStore.m in Sources */,
-				966F86CC18600B0500178A45 /* RequiredMethod_Tests.m in Sources */,
+				96C812BB1867D58D004B064E /* ResourceIdentifier_Tests.m in Sources */,
+				96C812BD1867D598004B064E /* RequiredMethod_Tests.m in Sources */,
 				963F1E9B18582B77009C50DF /* iOS_Test.m in Sources */,
-				966F86D018600D3600178A45 /* SaveRequest_Tests.m in Sources */,
 				9622F1081861416900020D4C /* TestManagedObjectModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -345,10 +343,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				966F86C3185FF8FE00178A45 /* ResourceIdentifier_Tests.m in Sources */,
-				966F86D218600D3F00178A45 /* RequiredMethod_Tests.m in Sources */,
 				963F1EAD18582B89009C50DF /* OS_X_Test.m in Sources */,
+				96C812BC1867D58E004B064E /* ResourceIdentifier_Tests.m in Sources */,
 				966F86D118600D3B00178A45 /* FetchRequest_Tests.m in Sources */,
+				96C812BE1867D598004B064E /* RequiredMethod_Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -431,7 +429,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -474,7 +471,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				TEST_HOST = "$(BUNDLE_LOADER)";
 				VALIDATE_PRODUCT = YES;
 				WRAPPER_EXTENSION = xctest;
 			};

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9622F1051861402E00020D4C /* TestIncrementalStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 9622F1041861402E00020D4C /* TestIncrementalStore.m */; };
+		9622F1081861416900020D4C /* TestManagedObjectModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 9622F1071861416900020D4C /* TestManagedObjectModel.m */; };
 		963F1E8F18582B77009C50DF /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 963F1E8E18582B77009C50DF /* XCTest.framework */; };
 		963F1E9118582B77009C50DF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 963F1E9018582B77009C50DF /* Foundation.framework */; };
 		963F1E9318582B77009C50DF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 963F1E9218582B77009C50DF /* UIKit.framework */; };
@@ -15,6 +17,13 @@
 		963F1EA518582B89009C50DF /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 963F1E8E18582B77009C50DF /* XCTest.framework */; };
 		963F1EAB18582B89009C50DF /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 963F1EA918582B89009C50DF /* InfoPlist.strings */; };
 		963F1EAD18582B89009C50DF /* OS_X_Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 963F1EAC18582B89009C50DF /* OS_X_Test.m */; };
+		966F86C3185FF8FE00178A45 /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96EE40E7185EB27B005887CC /* ResourceIdentifier_Tests.m */; };
+		966F86CC18600B0500178A45 /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
+		966F86CE18600D0900178A45 /* FetchRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CD18600D0900178A45 /* FetchRequest_Tests.m */; };
+		966F86D018600D3600178A45 /* SaveRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CF18600D3600178A45 /* SaveRequest_Tests.m */; };
+		966F86D118600D3B00178A45 /* FetchRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CD18600D0900178A45 /* FetchRequest_Tests.m */; };
+		966F86D218600D3F00178A45 /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
+		96EE40E8185EB27B005887CC /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96EE40E7185EB27B005887CC /* ResourceIdentifier_Tests.m */; };
 		A5FC87A080E44629BA8786E0 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C0140CE70AB4E6EA97A5A2F /* libPods-osx.a */; };
 		B8EFD6E709E1404693BD3FA9 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E84EF8B0347F4737BFABC2EC /* libPods-ios.a */; };
 /* End PBXBuildFile section */
@@ -23,6 +32,11 @@
 		026E70EDD8914070B191D1FB /* Pods-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.xcconfig"; path = "Pods/Pods-ios.xcconfig"; sourceTree = "<group>"; };
 		5C0140CE70AB4E6EA97A5A2F /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		685C3E9F6DFE47EB87EA0CA2 /* Pods-osx.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.xcconfig"; path = "Pods/Pods-osx.xcconfig"; sourceTree = "<group>"; };
+		9622F1031861402E00020D4C /* TestIncrementalStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestIncrementalStore.h; path = "Mock Objects/TestIncrementalStore.h"; sourceTree = "<group>"; };
+		9622F1041861402E00020D4C /* TestIncrementalStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestIncrementalStore.m; path = "Mock Objects/TestIncrementalStore.m"; sourceTree = "<group>"; };
+		9622F1061861416900020D4C /* TestManagedObjectModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestManagedObjectModel.h; path = "Mock Objects/TestManagedObjectModel.h"; sourceTree = "<group>"; };
+		9622F1071861416900020D4C /* TestManagedObjectModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestManagedObjectModel.m; path = "Mock Objects/TestManagedObjectModel.m"; sourceTree = "<group>"; };
+		9622F1091861500B00020D4C /* PFIncrementalStore_PrivateMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PFIncrementalStore_PrivateMethods.h; path = "Mock Objects/PFIncrementalStore_PrivateMethods.h"; sourceTree = "<group>"; };
 		963F1E8B18582B77009C50DF /* iOS Test.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Test.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		963F1E8E18582B77009C50DF /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		963F1E9018582B77009C50DF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -36,6 +50,10 @@
 		963F1EAA18582B89009C50DF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		963F1EAC18582B89009C50DF /* OS_X_Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OS_X_Test.m; sourceTree = "<group>"; };
 		963F1EAE18582B89009C50DF /* OS X Test-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OS X Test-Prefix.pch"; sourceTree = "<group>"; };
+		966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RequiredMethod_Tests.m; path = "Shared Tests/RequiredMethod_Tests.m"; sourceTree = "<group>"; };
+		966F86CD18600D0900178A45 /* FetchRequest_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FetchRequest_Tests.m; path = "Shared Tests/FetchRequest_Tests.m"; sourceTree = "<group>"; };
+		966F86CF18600D3600178A45 /* SaveRequest_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SaveRequest_Tests.m; path = "Shared Tests/SaveRequest_Tests.m"; sourceTree = "<group>"; };
+		96EE40E7185EB27B005887CC /* ResourceIdentifier_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ResourceIdentifier_Tests.m; path = "Shared Tests/ResourceIdentifier_Tests.m"; sourceTree = "<group>"; };
 		E84EF8B0347F4737BFABC2EC /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -63,9 +81,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9622F1021861400500020D4C /* Mock Objects */ = {
+			isa = PBXGroup;
+			children = (
+				9622F1091861500B00020D4C /* PFIncrementalStore_PrivateMethods.h */,
+				9622F1031861402E00020D4C /* TestIncrementalStore.h */,
+				9622F1041861402E00020D4C /* TestIncrementalStore.m */,
+				9622F1061861416900020D4C /* TestManagedObjectModel.h */,
+				9622F1071861416900020D4C /* TestManagedObjectModel.m */,
+			);
+			name = "Mock Objects";
+			sourceTree = "<group>";
+		};
 		963F1E8018582A5E009C50DF = {
 			isa = PBXGroup;
 			children = (
+				9622F1021861400500020D4C /* Mock Objects */,
+				96EE40E6185EB0C2005887CC /* Shared Tests */,
 				963F1E9418582B77009C50DF /* iOS Test */,
 				963F1EA618582B89009C50DF /* OS X Test */,
 				963F1E8D18582B77009C50DF /* Frameworks */,
@@ -132,6 +164,17 @@
 				963F1EAE18582B89009C50DF /* OS X Test-Prefix.pch */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		96EE40E6185EB0C2005887CC /* Shared Tests */ = {
+			isa = PBXGroup;
+			children = (
+				96EE40E7185EB27B005887CC /* ResourceIdentifier_Tests.m */,
+				966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */,
+				966F86CD18600D0900178A45 /* FetchRequest_Tests.m */,
+				966F86CF18600D3600178A45 /* SaveRequest_Tests.m */,
+			);
+			name = "Shared Tests";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -288,7 +331,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				966F86CE18600D0900178A45 /* FetchRequest_Tests.m in Sources */,
+				96EE40E8185EB27B005887CC /* ResourceIdentifier_Tests.m in Sources */,
+				9622F1051861402E00020D4C /* TestIncrementalStore.m in Sources */,
+				966F86CC18600B0500178A45 /* RequiredMethod_Tests.m in Sources */,
 				963F1E9B18582B77009C50DF /* iOS_Test.m in Sources */,
+				966F86D018600D3600178A45 /* SaveRequest_Tests.m in Sources */,
+				9622F1081861416900020D4C /* TestManagedObjectModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -296,7 +345,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				966F86C3185FF8FE00178A45 /* ResourceIdentifier_Tests.m in Sources */,
+				966F86D218600D3F00178A45 /* RequiredMethod_Tests.m in Sources */,
 				963F1EAD18582B89009C50DF /* OS_X_Test.m in Sources */,
+				966F86D118600D3B00178A45 /* FetchRequest_Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -379,6 +431,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -421,6 +474,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				TEST_HOST = "$(BUNDLE_LOADER)";
 				VALIDATE_PRODUCT = YES;
 				WRAPPER_EXTENSION = xctest;
 			};

--- a/Tests/iOS Test/iOS Test-Prefix.pch
+++ b/Tests/iOS Test/iOS Test-Prefix.pch
@@ -7,4 +7,6 @@
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
+
+    #import <PFIncrementalStore/PFIncrementalStore.h>
 #endif

--- a/Tests/iOS Test/iOS_Test.m
+++ b/Tests/iOS Test/iOS_Test.m
@@ -6,24 +6,8 @@
 //
 //
 
-#import <XCTest/XCTest.h>
+#import <Kiwi/Kiwi.h>
 
-@interface iOS_Test : XCTestCase
+SPEC_BEGIN(iOSSpecificTests)
 
-@end
-
-@implementation iOS_Test
-
-- (void)setUp
-{
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown
-{
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
-@end
+SPEC_END


### PR DESCRIPTION
Currently, the IncrementalStore is not connected to any persistent store, it is merely a basic translator between CoreData and Parse. To operate like a true IncrementalStore, it must persist data via the store coordinator.
