### PR TITLE
Temporarily remove support for OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,9 @@ before_install:
     - brew update
     - brew uninstall xctool && brew install xctool --HEAD
     - cd Tests && pod install && cd $TRAVIS_BUILD_DIR
-script: rake test
+script: rake test_for_target
+env:
+    - TEST_TARGET=ios
+    - TEST_TARGET=osx
+allow_failures:
+    - env: "TEST_TARGET=osx"

--- a/PFIncrementalStore.podspec
+++ b/PFIncrementalStore.podspec
@@ -6,7 +6,6 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
 
   s.ios.deployment_target = '5.0'
-  s.osx.deployment_target = '10.7'
 
   s.source       = { :git => "https://github.com/sbonami/PFIncrementalStore.git", :tag => "0.0.1" }
   s.source_files = 'PFIncrementalStore', 'PFIncrementalStore/**/*.{h,m}'
@@ -17,5 +16,4 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.ios.dependency 'Parse-iOS-SDK'
-  s.osx.dependency 'Parse-OSX-SDK'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -25,4 +25,17 @@ task :test => ['test:ios', 'test:osx'] do
   end
 end
 
+desc "Run the PFIncrementalStore Tests for target set in TEST_TARGET"
+task :test_for_target do
+  exit(-1) if !['ios', 'osx'].include? ENV['TEST_TARGET']
+
+  task_to_run = "test:#{ENV['TEST_TARGET']}"
+  Rake::Task[task_to_run].reenable
+  if Rake::Task[task_to_run].invoke
+    puts "\033[0;32m** Target tests executed successfully"
+  else
+    exit(-1)
+  end
+end
+
 task :default => 'test'

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -6,14 +6,8 @@ def import_pods
   pod 'PFIncrementalStore', :path => '../'
 end
 
-target :ios do
+target :ios, exclusive: true do
   platform :ios, '7.0'
   link_with 'iOS Test'
-  import_pods
-end
-
-target :osx do
-  platform :osx, '10.9'
-  link_with 'OS X Test'
   import_pods
 end

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -2,10 +2,8 @@ PODS:
   - Facebook-iOS-SDK (3.10.0)
   - Parse-iOS-SDK (1.2.17):
     - Facebook-iOS-SDK (~> 3.7)
-  - Parse-OSX-SDK (1.2.17)
   - PFIncrementalStore (0.0.1):
     - Parse-iOS-SDK
-    - Parse-OSX-SDK
 
 DEPENDENCIES:
   - PFIncrementalStore (from `../`)
@@ -17,7 +15,6 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Facebook-iOS-SDK: ef402579aeb30cf0c4a6370fb0a927e3dc3059e5
   Parse-iOS-SDK: f57fc3a7b80c7135d5acdc55a0fbc3ab2d1d5027
-  Parse-OSX-SDK: 3640c1f1f60cc6a3ae0e01757bc809a3a4468827
-  PFIncrementalStore: 943720374826cb62a71b1cb90416e8054dc0f347
+  PFIncrementalStore: 98ef32d7cb2a4ebaf46fea5fa52d4b028b1d84ad
 
 COCOAPODS: 0.28.0


### PR DESCRIPTION
To get _PFIncrementalStore_ closer to launch, remove OS X support temporarily with plans to re-launch OS X as soon as debugging can commence. For currently unknown reasons, OS X cannot run nor does it pass an empty test suite.
