### PR TITLE
Multiple inserted object relationships do not save

### DIFF
--- a/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
+++ b/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
@@ -75,6 +75,6 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 
 @interface PFObject (_PFIncrementalStore)
 
-- (void)setValuesFromManagedObject:(NSManagedObject *)managedObject;
+- (void)setValuesFromManagedObject:(NSManagedObject *)managedObject withSaveCallbacks:(NSMutableDictionary **)saveCallbacks;
 
 @end

--- a/Tests/Shared Tests/SaveRequest_Tests.m
+++ b/Tests/Shared Tests/SaveRequest_Tests.m
@@ -77,11 +77,11 @@ describe(@"executeSaveChangesRequest:withContext:error:", ^{
             [saveChangesRequest stub:@selector(insertedObjects) andReturn:@[testEntity]];
             
             [testObject stub:@selector(saveInBackgroundWithBlock:)];
-            [testObject stub:@selector(setValuesFromManagedObject:) andReturn:nil];
+            [testObject stub:@selector(setValuesFromManagedObject:withSaveCallbacks:) andReturn:nil];
         });
         
         it(@"should set the Parse Object values from the managed object", ^{
-            [[testObject should] receive:@selector(setValuesFromManagedObject:)];
+            [[testObject should] receive:@selector(setValuesFromManagedObject:withSaveCallbacks:)];
             
             [testIncrementalStore executeSaveChangesRequest:saveChangesRequest withContext:testManagedObjectContext error:nil];
         });
@@ -323,13 +323,13 @@ describe(@"executeSaveChangesRequest:withContext:error:", ^{
                     it(@"should update the fetched object with the values from the updated object", ^{
                         [testObject stub:@selector(saveInBackgroundWithBlock:)];
                         
-                        [[testObject should] receive:@selector(setValuesFromManagedObject:) withArguments:testEntity];
+                        [[testObject should] receive:@selector(setValuesFromManagedObject:withSaveCallbacks:) withArguments:testEntity, nil];
                         
                         fetchBlockToRun(testObject, nil);
                     });
                     
                     it(@"should save the parse object", ^{
-                        [testObject stub:@selector(setValuesFromManagedObject:)];
+                        [testObject stub:@selector(setValuesFromManagedObject:withSaveCallbacks:)];
                         
                         [[testObject should] receive:@selector(saveInBackgroundWithBlock:)];
                         
@@ -340,7 +340,7 @@ describe(@"executeSaveChangesRequest:withContext:error:", ^{
                         __block PFBooleanResultBlock saveBlockToRun = nil;
                         
                         beforeEach(^{
-                            [testObject stub:@selector(setValuesFromManagedObject:)];
+                            [testObject stub:@selector(setValuesFromManagedObject:withSaveCallbacks:)];
                             
                             KWCaptureSpy *spy = [testObject captureArgument:@selector(saveInBackgroundWithBlock:) atIndex:0];
                             fetchBlockToRun(testObject, nil);


### PR DESCRIPTION
When creating multiple new objects and relating them, the relationships do not get saved. Since the object has not yet been synced with Parse, it has not yet been assigned a Parse objectId.
