### PR TITLE
Fix Rakefile so Travis test failures are properly reported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,7 @@ script: rake test_for_target
 env:
     - TEST_TARGET=ios
     - TEST_TARGET=osx
-allow_failures:
-    - env: "TEST_TARGET=osx"
+matrix:
+    fast_finish: true
+    allow_failures:
+        - env: "TEST_TARGET=osx"

--- a/Rakefile
+++ b/Rakefile
@@ -5,12 +5,12 @@ namespace :test do
 
   desc "Run the PFIncrementalStore Tests for iOS"
   task :ios => :prepare do
-    $ios_success = system("xctool -workspace PFIncrementalStore.xcworkspace -scheme 'iOS Test' -sdk iphonesimulator -configuration Release test -test-sdk iphonesimulator")
+    $ios_success = $target_success = system("xctool -workspace PFIncrementalStore.xcworkspace -scheme 'iOS Test' -sdk iphonesimulator -configuration Release test -test-sdk iphonesimulator")
   end
 
   desc "Run the PFIncrementalStore Tests for Mac OS X"
   task :osx => :prepare do
-    $osx_success = system("xctool -workspace PFIncrementalStore.xcworkspace -scheme 'OS X Test' -sdk macosx -configuration Release test -test-sdk macosx")
+    $osx_success = $target_success = system("xctool -workspace PFIncrementalStore.xcworkspace -scheme 'OS X Test' -sdk macosx -configuration Release test -test-sdk macosx")
   end
 end
 
@@ -31,7 +31,8 @@ task :test_for_target do
 
   task_to_run = "test:#{ENV['TEST_TARGET']}"
   Rake::Task[task_to_run].reenable
-  if Rake::Task[task_to_run].invoke
+  Rake::Task[task_to_run].invoke
+  if $target_success
     puts "\033[0;32m** Target tests executed successfully"
   else
     exit(-1)


### PR DESCRIPTION
Currently, all travis builds succeed via the `test_for_target` command since `Rake::Task.invoke` doesn't return false if tests fail.
