### PR TITLE
Fix cascade deletion of related objects

### DIFF
--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -471,8 +471,10 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
                         
                         [backingContext performBlockAndWait:^{
                             NSManagedObject *backingObject = [backingContext existingObjectWithID:backingObjectID error:nil];
-                            [backingContext deleteObject:backingObject];
-                            [backingContext save:nil];
+                            if (backingObject) {
+                                [backingContext deleteObject:backingObject];
+                                [backingContext save:nil];
+                            }
                         }];
                     } else {
                         NSLog(@"Delete Error: %@", error);


### PR DESCRIPTION
Assume the following situation:

`Object A`
- relationship to `Object B`, cascade on delete

`Object B`
- inverse relationship to `Object A`, 

Problem: Delete `Object A` causes crash while deleting from backing context after Parse response since Core Data has already taken care of deleting the child object.
