### PR TITLE
WIP - Add Parse Reserved Object Support

### DIFF
--- a/PFIncrementalStore.xcworkspace/contents.xcworkspacedata
+++ b/PFIncrementalStore.xcworkspace/contents.xcworkspacedata
@@ -25,6 +25,12 @@
          <FileRef
             location = "group:PFIncrementalStore/PFReservedObject.m">
          </FileRef>
+         <FileRef
+            location = "group:PFIncrementalStore/PFProxyUser.h">
+         </FileRef>
+         <FileRef
+            location = "group:PFIncrementalStore/PFProxyUser.m">
+         </FileRef>
       </Group>
    </Group>
    <FileRef

--- a/PFIncrementalStore.xcworkspace/contents.xcworkspacedata
+++ b/PFIncrementalStore.xcworkspace/contents.xcworkspacedata
@@ -16,6 +16,16 @@
       <FileRef
          location = "group:PFIncrementalStore/NSManagedObject_PFIncrementalStore.h">
       </FileRef>
+      <Group
+         location = "container:"
+         name = "Reserved Parse Objects">
+         <FileRef
+            location = "group:PFIncrementalStore/PFReservedObject.h">
+         </FileRef>
+         <FileRef
+            location = "group:PFIncrementalStore/PFReservedObject.m">
+         </FileRef>
+      </Group>
    </Group>
    <FileRef
       location = "group:Tests/Tests.xcodeproj">

--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -191,7 +191,8 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
 
 - (id)relatedObjectsForRelationship:(NSRelationshipDescription *)relationship {
     id relatedObjects = nil;
-    if (relationship.isToMany) {
+    
+    if (relationship.isToMany && !relationship.inverseRelationship.isToMany) {
         PFQuery *query = [PFQuery queryWithClassName:relationship.destinationEntity.parseQueryClassName];
         [query whereKey:relationship.inverseRelationship.name equalTo:self];
         relatedObjects = [query findObjects];
@@ -231,8 +232,6 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
 - (id)executeFetchRequest:(NSFetchRequest *)fetchRequest
               withContext:(NSManagedObjectContext *)context
                     error:(NSError *__autoreleasing *)error {
-    
-    NSLog(@"%@",fetchRequest.entity.parseQueryClassName);
     
     PFQuery *query = [PFQuery queryWithClassName:fetchRequest.entity.parseQueryClassName predicate:fetchRequest.predicate];
     [query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {

--- a/PFIncrementalStore/PFProxyUser.h
+++ b/PFIncrementalStore/PFProxyUser.h
@@ -1,0 +1,38 @@
+// PFProxyUser.h
+//
+// Copyright (c) 2013 Scott BonAmi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <CoreData/CoreData.h>
+#import <Parse-iOS-SDK/Parse.h>
+
+@interface PFUser ()
+-(NSManagedObject *)managedObject;
+@end
+
+@interface PFProxyUser : PFUser <PFSubclassing>
+
++(NSString *)reservedObjectSubclass;
++(void)setReservedObjectSubclass:(NSString *)reservedObjectSubclass;
+
++(NSManagedObjectContext *)defaultContext;
++(void)setDefaultContext:(NSManagedObjectContext *)defaultContext;
+
+@end

--- a/PFIncrementalStore/PFProxyUser.m
+++ b/PFIncrementalStore/PFProxyUser.m
@@ -1,0 +1,58 @@
+// PFProxyUser.m
+//
+// Copyright (c) 2013 Scott BonAmi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "PFProxyUser.h"
+#import "PFReservedObject.h"
+#import "NSManagedObject_PFIncrementalStore.h"
+
+static NSString *staticReservedObjectSubclass = nil;
+static NSManagedObjectContext *staticDefaultContext = nil;
+@implementation PFProxyUser
+
++(void)initialize {
+    [self registerSubclass];
+}
+
++(NSString *)reservedObjectSubclass {
+    return staticReservedObjectSubclass;
+}
+
++(void)setReservedObjectSubclass:(NSString *)reservedObjectSubclass {
+    staticReservedObjectSubclass = reservedObjectSubclass;
+}
+
++(NSManagedObjectContext *)defaultContext {
+    return staticDefaultContext;
+}
+
++(void)setDefaultContext:(NSManagedObjectContext *)defaultContext {
+    staticDefaultContext = defaultContext;
+}
+
+-(NSManagedObject *)managedObject {
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:staticReservedObjectSubclass];
+    [fetchRequest setPredicate:[NSPredicate predicateWithFormat:@"%K = %@", kPFIncrementalStoreResourceIdentifierAttributeName, self.objectId]];
+    id result = [staticDefaultContext executeFetchRequest:fetchRequest error:nil];
+    return (result) ? [result objectAtIndex:0] : nil ;
+}
+
+@end

--- a/PFIncrementalStore/PFReservedObject.h
+++ b/PFIncrementalStore/PFReservedObject.h
@@ -1,0 +1,27 @@
+// PFReservedObject.h
+//
+// Copyright (c) 2013 Scott BonAmi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <CoreData/CoreData.h>
+
+@interface PFReservedObject : NSManagedObject
+
+@end

--- a/PFIncrementalStore/PFReservedObject.m
+++ b/PFIncrementalStore/PFReservedObject.m
@@ -1,0 +1,66 @@
+// PFReservedObject.m
+//
+// Copyright (c) 2013 Scott BonAmi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <CoreData/CoreData.h>
+#import <Parse-iOS-SDK/Parse.h>
+
+#import "PFReservedObject.h"
+#import "PFIncrementalStore.h"
+#import "NSManagedObject_PFIncrementalStore.h"
+
+@implementation PFReservedObject
+
+-(PFObject *)reservedObject {
+    NSUInteger index = [@[@"_User", @"_Role", @"_Product", @"_Installation"] indexOfObject:self.parseQueryClassName];
+    NSAssert(index != NSNotFound, @"PFReservedObject subclass should return one of 'PFUser', 'PFRole', 'PFProduct', or 'PFInstallation'");
+    
+    PFQuery *query = [PFQuery queryWithClassName:self.parseQueryClassName];
+    return [query getObjectWithId:self.pf_resourceIdentifier];
+}
+
+#pragma mark - Message Forwarding
+
+-(BOOL)respondsToSelector:(SEL)aSelector {
+    if (self.reservedObject) {
+        return [self.reservedObject respondsToSelector:aSelector];
+    }
+    return [super respondsToSelector:aSelector];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    if ([self.reservedObject respondsToSelector:[anInvocation selector]]) {
+        [anInvocation invokeWithTarget:self.reservedObject];
+    } else {
+        [super forwardInvocation:anInvocation];
+    }
+}
+
+-(id)valueForUndefinedKey:(NSString *)key {
+    return [self.reservedObject valueForKey:key];
+}
+
+- (void)setValue:(id)value forUndefinedKey:(NSString *)key {
+    [self.reservedObject setValue:value forKey:key];
+}
+
+@end


### PR DESCRIPTION
Usage:

1) Include the `PFProxyUser` header file wherever you initialize your Parse

```
#import <PFIncrementalStore/PFProxyUser.h>
```

2) Initialize the PFProxyUser Object

```
[PFProxyUser registerSubclass];
[PFProxyUser setReservedObjectSubclass:<# Parse Reserved Object Subclass Name #>];
[PFProxyUser setDefaultContext:self.managedObjectContext];
```

3) Include the `PFReservedObject` header file in the NSManagedObject subclass file correlating to your Parse Reserved Object Subclass

```
#import <PFIncrementalStore/PFReservedObject.h>
```

4) Change the subclass from an `NSManagedObject` to a `PFReservedObject`

```
@interface <# Parse Reserved Object Subclass Name #> : PFReservedObject
@end
```

5) Add the key `ParseClassName` and value `PFUser` to your Parse Reserved Object Subclass in your Core Data Model

![screenshot 2014-01-27 23 38 44](https://f.cloud.github.com/assets/1145657/2016345/17a81ccc-87d6-11e3-9dab-fbd897739a16.png)

You can now access a `PFUser`'s corresponding `NSManagedObject` by calling the `managedObject` method on it.

```
[[PFUser currentUser] managedObject]
```

You can call a `PFUser`'s attributes and methods on the `NSManagedObject`.

```
[object email] => [user email]
```
