### PR TITLE
Add ability to select parse class name

### DIFF
--- a/PFIncrementalStore.xcworkspace/contents.xcworkspacedata
+++ b/PFIncrementalStore.xcworkspace/contents.xcworkspacedata
@@ -13,6 +13,9 @@
       <FileRef
          location = "group:PFIncrementalStore/PFIncrementalStore.m">
       </FileRef>
+      <FileRef
+         location = "group:PFIncrementalStore/NSManagedObject_PFIncrementalStore.h">
+      </FileRef>
    </Group>
    <FileRef
       location = "group:Tests/Tests.xcodeproj">

--- a/PFIncrementalStore/NSManagedObject_PFIncrementalStore.h
+++ b/PFIncrementalStore/NSManagedObject_PFIncrementalStore.h
@@ -30,4 +30,7 @@ extern NSString * const kPFIncrementalStoreResourceIdentifierAttributeName;
 
 @property (readwrite, nonatomic, copy, setter = pf_setResourceIdentifier:) NSString *pf_resourceIdentifier;
 
+-(NSString *)parseClassName;
+-(NSString *)parseQueryClassName;
+
 @end

--- a/PFIncrementalStore/NSManagedObject_PFIncrementalStore.h
+++ b/PFIncrementalStore/NSManagedObject_PFIncrementalStore.h
@@ -1,0 +1,33 @@
+// NSManagedObject_PFIncrementalStore.h
+//
+// Copyright (c) 2013 Scott BonAmi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <CoreData/CoreData.h>
+
+extern NSString * const kPFReferenceObjectPrefix;
+extern NSString * const kPFIncrementalStoreLastModifiedAttributeName;
+extern NSString * const kPFIncrementalStoreResourceIdentifierAttributeName;
+
+@interface NSManagedObject (_PFIncrementalStore)
+
+@property (readwrite, nonatomic, copy, setter = pf_setResourceIdentifier:) NSString *pf_resourceIdentifier;
+
+@end

--- a/PFIncrementalStore/PFIncrementalStore.h
+++ b/PFIncrementalStore/PFIncrementalStore.h
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #import <CoreData/CoreData.h>
+#import "NSManagedObject_PFIncrementalStore.h"
 
 @interface PFIncrementalStore : NSIncrementalStore
 

--- a/PFIncrementalStore/PFIncrementalStore.h
+++ b/PFIncrementalStore/PFIncrementalStore.h
@@ -157,6 +157,11 @@ extern NSString * const PFIncrementalStoreContextDidFetchNewValuesForRelationshi
 //------------------------------------------------------------------------------
 
 /**
+ A key in the `userInfo` dictionary in an `NSManagedObject` corresponding to the Parse Class Name with which the entity should synchronize.
+ */
+extern NSString * const PFIncrementalStoreManagedObjectEntityParseClassName;
+
+/**
  A key in the `userInfo` dictionary in a `PFIncrementalStoreContextWillFetchRemoteValues` or `PFIncrementalStoreContextDidFetchRemoteValues` as well as `PFIncrementalStoreContextWillSaveRemoteValues` or `PFIncrementalStoreContextDidSaveRemoteValues` notifications.
  The corresponding value is an `NSArray` of `AFHTTPRequestOperation` objects corresponding to the request operations triggered by the fetch or save changes request.
  */

--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -36,6 +36,7 @@ NSString * const PFIncrementalStoreContextWillFetchNewValuesForObject = @"PFIncr
 NSString * const PFIncrementalStoreContextDidFetchNewValuesForObject = @"PFIncrementalStoreContextDidFetchNewValuesForObject";
 NSString * const PFIncrementalStoreContextWillFetchNewValuesForRelationship = @"PFIncrementalStoreContextWillFetchNewValuesForRelationship";
 NSString * const PFIncrementalStoreContextDidFetchNewValuesForRelationship = @"PFIncrementalStoreContextDidFetchNewValuesForRelationship";
+NSString * const PFIncrementalStoreManagedObjectEntityParseClassName = @"ParseClassName";
 NSString * const PFIncrementalStoreRequestOperationsKey = @"PFIncrementalStoreRequestOperations";
 NSString * const PFIncrementalStoreFetchedObjectIDsKey = @"PFIncrementalStoreFetchedObjectIDs";
 NSString * const PFIncrementalStoreFaultingObjectIDKey = @"PFIncrementalStoreFaultingObjectID";
@@ -78,8 +79,32 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
     }
 }
 
+@implementation NSEntityDescription (_PFIncrementalStore)
+
+-(NSString *)parseClassNameFromSubclass {
+    NSString *parseClassNameFromSubclass = [self.userInfo objectForKey:PFIncrementalStoreManagedObjectEntityParseClassName];
+    return (parseClassNameFromSubclass) ? parseClassNameFromSubclass : self.name ;
+}
+
+-(NSString *)parseQueryClassName {
+    if ([[self.parseClassNameFromSubclass substringWithRange:NSMakeRange(0, 2)] isEqual: @"PF"]) {
+        return [self.parseClassNameFromSubclass stringByReplacingCharactersInRange:NSMakeRange(0, 2) withString:@"_"];
+    }
+    return self.parseClassNameFromSubclass;
+}
+
+@end
+
 @implementation NSManagedObject (_PFIncrementalStore)
 @dynamic pf_resourceIdentifier;
+
+-(NSString *)parseClassName {
+    return self.entity.parseClassNameFromSubclass;
+}
+
+-(NSString *)parseQueryClassName {
+    return self.entity.parseQueryClassName;
+}
 
 - (NSString *)pf_resourceIdentifier {
     NSString *identifier = (NSString *)objc_getAssociatedObject(self, &kPFResourceIdentifierObjectKey);
@@ -135,7 +160,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
             if (!relationship.isToMany) {
                 NSManagedObject *relatedManagedObject = (NSManagedObject *)value;
                 if (relatedManagedObject.pf_resourceIdentifier) {
-                    PFQuery *query = [PFQuery queryWithClassName:relationship.destinationEntity.name];
+                    PFQuery *query = [PFQuery queryWithClassName:relationship.destinationEntity.parseQueryClassName];
                     PFObject *relatedParseObject = [query getObjectWithId:PFResourceIdentifierFromReferenceObject(relatedManagedObject.pf_resourceIdentifier)];
                     [self setObject:relatedParseObject forKey:relationshipName];
                 } else {
@@ -167,7 +192,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
 - (id)relatedObjectsForRelationship:(NSRelationshipDescription *)relationship {
     id relatedObjects = nil;
     if (relationship.isToMany) {
-        PFQuery *query = [PFQuery queryWithClassName:relationship.destinationEntity.name];
+        PFQuery *query = [PFQuery queryWithClassName:relationship.destinationEntity.parseQueryClassName];
         [query whereKey:relationship.inverseRelationship.name equalTo:self];
         relatedObjects = [query findObjects];
     } else {
@@ -207,7 +232,9 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
               withContext:(NSManagedObjectContext *)context
                     error:(NSError *__autoreleasing *)error {
     
-    PFQuery *query = [PFQuery queryWithClassName:fetchRequest.entityName predicate:fetchRequest.predicate];
+    NSLog(@"%@",fetchRequest.entity.parseQueryClassName);
+    
+    PFQuery *query = [PFQuery queryWithClassName:fetchRequest.entity.parseQueryClassName predicate:fetchRequest.predicate];
     [query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
         if (error) {
             NSLog(@"Error: %@, %@", query, error);
@@ -275,7 +302,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
     
     NSManagedObjectContext *backingContext = [self backingManagedObjectContext];
     NSFetchRequest *backingFetchRequest = [fetchRequest copy];
-    backingFetchRequest.entity = [NSEntityDescription entityForName:fetchRequest.entityName inManagedObjectContext:backingContext];
+    backingFetchRequest.entity = [NSEntityDescription entityForName:fetchRequest.entity.name inManagedObjectContext:backingContext];
     backingFetchRequest.resultType = NSDictionaryResultType;
     backingFetchRequest.propertiesToFetch = [NSArray arrayWithObject:kPFIncrementalStoreResourceIdentifierAttributeName];
     NSArray *results = [backingContext executeFetchRequest:backingFetchRequest error:error];
@@ -368,7 +395,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
 -(void)insertObject:(NSManagedObject *)insertedObject fromRequest:(NSSaveChangesRequest *)request inContext:(NSManagedObjectContext *)context error:(NSError *__autoreleasing *)error {
     NSManagedObjectContext *backingContext = [self backingManagedObjectContext];
     
-    PFObject *object = [PFObject objectWithClassName:insertedObject.entity.name];
+    PFObject *object = [PFObject objectWithClassName:insertedObject.entity.parseQueryClassName];
     
     __block NSMutableDictionary *saveCallbacks = [NSMutableDictionary dictionary];
     [object setValuesFromManagedObject:insertedObject withSaveCallbacks:&saveCallbacks];
@@ -445,7 +472,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
     
     NSManagedObjectID *backingObjectID = [self managedObjectIDForBackingObjectForEntity:[updatedObject entity] withParseObjectId:PFResourceIdentifierFromReferenceObject([self referenceObjectForObjectID:updatedObject.objectID])];
     
-    PFQuery *query = [PFQuery queryWithClassName:updatedObject.entity.name];
+    PFQuery *query = [PFQuery queryWithClassName:updatedObject.entity.parseQueryClassName];
     [query getObjectInBackgroundWithId:updatedObject.pf_resourceIdentifier block:^(PFObject *object, NSError *error) {
         if (error) {
             NSLog(@"Fetch Before Update Error: %@",error);
@@ -482,7 +509,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
     
     NSManagedObjectID *backingObjectID = [self managedObjectIDForBackingObjectForEntity:[deletedObject entity] withParseObjectId:PFResourceIdentifierFromReferenceObject([self referenceObjectForObjectID:deletedObject.objectID])];
     
-    PFQuery *query = [PFQuery queryWithClassName:deletedObject.entity.name];
+    PFQuery *query = [PFQuery queryWithClassName:deletedObject.entity.parseQueryClassName];
     [query getObjectInBackgroundWithId:deletedObject.pf_resourceIdentifier block:^(PFObject *object, NSError *error) {
         if (error) {
             NSLog(@"Fetch Before Delete Error: %@",error);
@@ -606,7 +633,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
         childContext.parentContext = context;
         childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
         
-        PFQuery *query = [[PFQuery alloc] initWithClassName:fetchRequest.entityName];
+        PFQuery *query = [[PFQuery alloc] initWithClassName:fetchRequest.entity.parseQueryClassName];
         [query getObjectInBackgroundWithId:PFResourceIdentifierFromReferenceObject([self referenceObjectForObjectID:objectID]) block:^(PFObject *object, NSError *error) {
             if (error) {
                 NSLog(@"Error: %@, %@", query, error);
@@ -654,7 +681,7 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
         childContext.parentContext = context;
         childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
         
-        PFQuery *query = [[PFQuery alloc] initWithClassName:objectID.entity.name];
+        PFQuery *query = [[PFQuery alloc] initWithClassName:objectID.entity.parseQueryClassName];
         [query getObjectInBackgroundWithId:PFResourceIdentifierFromReferenceObject([self referenceObjectForObjectID:objectID]) block:^(PFObject *object, NSError *error) {
             if (error) {
                 NSLog(@"Error: %@, %@", query, error);
@@ -995,7 +1022,7 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 
 - (NSDictionary *)valuesForEntity:(NSEntityDescription *)entity
                 withParseObjectId:(NSString *)referenceObject {
-    PFQuery *query = [[PFQuery alloc] initWithClassName:entity.name];
+    PFQuery *query = [[PFQuery alloc] initWithClassName:entity.parseQueryClassName];
     PFObject *object = [query getObjectWithId:PFResourceIdentifierFromReferenceObject(referenceObject)];
     
     NSMutableDictionary *values = [NSMutableDictionary dictionary];

--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -1,4 +1,3 @@
-
 // PFIncrementalStore.m
 //
 // Copyright (c) 2013 Scott BonAmi
@@ -51,9 +50,9 @@ typedef void (^PFInsertUpdateResponseBlock)(NSArray *managedObjects, NSArray *ba
 
 static char kPFResourceIdentifierObjectKey;
 
-static NSString * const kPFReferenceObjectPrefix = @"__pf_";
-static NSString * const kPFIncrementalStoreLastModifiedAttributeName = @"__pf_lastModified";
-static NSString * const kPFIncrementalStoreResourceIdentifierAttributeName = @"__pf_resourceIdentifier";
+NSString * const kPFReferenceObjectPrefix = @"__pf_";
+NSString * const kPFIncrementalStoreLastModifiedAttributeName = @"__pf_lastModified";
+NSString * const kPFIncrementalStoreResourceIdentifierAttributeName = @"__pf_resourceIdentifier";
 
 inline NSString * PFReferenceObjectFromResourceIdentifier(NSString *resourceIdentifier) {
     if (!resourceIdentifier) {
@@ -78,10 +77,6 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:error forKey:NSUnderlyingErrorKey]];
     }
 }
-
-@interface NSManagedObject (_PFIncrementalStore)
-@property (readwrite, nonatomic, copy, setter = pf_setResourceIdentifier:) NSString *pf_resourceIdentifier;
-@end
 
 @implementation NSManagedObject (_PFIncrementalStore)
 @dynamic pf_resourceIdentifier;
@@ -1022,8 +1017,6 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
     
     return values;
 }
-
-
 
 #pragma mark - Notification Methods
 

--- a/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
+++ b/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
@@ -13,10 +13,6 @@
 static NSString * const kPFIncrementalStoreErrorDomain = @"PFIncrementalStoreErrorDomain";
 static NSString * const kPFIncrementalStoreUnimplementedMethodException = @"PFIncrementalStoreUnimplementedMethodException";
 
-static NSString * const kPFReferenceObjectPrefix = @"__pf_";
-static NSString * const kPFIncrementalStoreLastModifiedAttributeName = @"__pf_lastModified";
-static NSString * const kPFIncrementalStoreResourceIdentifierAttributeName = @"__pf_resourceIdentifier";
-
 inline NSString * PFReferenceObjectFromResourceIdentifier(NSString *resourceIdentifier);
 inline NSString * PFResourceIdentifierFromReferenceObject(id referenceObject);
 


### PR DESCRIPTION
Add ability to select parse class name. This allows you to use the core-data "prefix" (like PF), but not translate that over to Parse objects.
