### PR TITLE
Add PFFile support

### DIFF
--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -130,8 +130,25 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
     [mutableAttributeValues removeObjectForKey:kPFIncrementalStoreResourceIdentifierAttributeName];
     [mutableAttributeValues removeObjectForKey:kPFIncrementalStoreLastModifiedAttributeName];
     for (NSString *attributeName in mutableAttributeValues) {
-        [self setValue:[parseObject objectForKey:attributeName] forKey:attributeName];
+        id parseValue = [parseObject objectForKey:attributeName];
+        if ([parseValue isKindOfClass:[PFFile class]]) {
+            [self setPFFile:parseValue forKey:attributeName];
+        } else {
+            [self setValue:parseValue forKey:attributeName];
+        }
     }
+}
+
+- (void)setPFFile:(PFFile *)file forKey:(NSString *)key {
+    [self setValue:[file getData] forKey:key];
+}
+
+@end
+
+@implementation NSMutableDictionary (_PFIncrementalStore)
+
+- (void)setPFFile:(PFFile *)file forKey:(NSString *)key {
+    [self setObject:[file getData] forKey:key];
 }
 
 @end
@@ -648,7 +665,12 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
                     [mutableAttributeValues removeObjectForKey:kPFIncrementalStoreResourceIdentifierAttributeName];
                     [mutableAttributeValues removeObjectForKey:kPFIncrementalStoreLastModifiedAttributeName];
                     for (NSString *attributeName in fetchRequest.entity.attributesByName) {
-                        [mutableAttributeValues setObject:[object objectForKey:attributeName] forKey:attributeName];
+                        id parseValue = [object objectForKey:attributeName];
+                        if ([parseValue isKindOfClass:[PFFile class]]) {
+                            [mutableAttributeValues setPFFile:parseValue forKey:attributeName];
+                        } else {
+                            [mutableAttributeValues setObject:parseValue forKey:attributeName];
+                        }
                     }
                     
                     [managedObject setValuesForKeysWithDictionary:mutableAttributeValues];

--- a/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
+++ b/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
@@ -84,6 +84,14 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 
 - (void)setValuesFromParseObject:(PFObject *)parseObject;
 
+- (void)setPFFile:(PFFile *)file forKey:(NSString *)key;
+
+@end
+
+@interface NSMutableDictionary (_PFIncrementalStore)
+
+- (void)setPFFile:(PFFile *)file forKey:(NSString *)key;
+
 @end
 
 @interface PFObject (_PFIncrementalStore)

--- a/Tests/Shared Tests/Categories/NSManagedObject_Tests.m
+++ b/Tests/Shared Tests/Categories/NSManagedObject_Tests.m
@@ -1,0 +1,53 @@
+//
+//  NSManagedObject_Tests.m
+//  Shared Tests
+//
+//  Created by Scott BonAmi on 3/4/14.
+//
+//
+
+#import <Kiwi/Kiwi.h>
+#import "PFIncrementalStore_PrivateMethods.h"
+
+#import "TestManagedObjectModel.h"
+
+@interface TestNSManagedObject : NSManagedObject
+@property (nonatomic, strong) NSString *testAttribute;
+@end
+
+@implementation TestNSManagedObject
+@synthesize testAttribute;
+@end
+
+SPEC_BEGIN(Category_NSManagedObject_Tests)
+
+describe(@"setPFFile:forKey:", ^{
+    __block PFFile *testFile = nil;
+    __block NSData *testFileData = nil;
+    __block NSManagedObject *testObject = nil;
+    
+    beforeEach(^{
+        testFile = [PFFile nullMock];
+        testFileData = [NSData nullMock];
+        
+        TestManagedObjectModel *testManagedObjectModel = [[TestManagedObjectModel alloc] init];
+        NSPersistentStoreCoordinator *testPersistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:testManagedObjectModel];
+        
+        NSManagedObjectContext *testManagedObjectContext = [[NSManagedObjectContext alloc] init];
+        [testManagedObjectContext setPersistentStoreCoordinator:testPersistentStoreCoordinator];
+        
+        NSEntityDescription *testEntityDescription = [NSEntityDescription entityForName:@"TestEntity" inManagedObjectContext:testManagedObjectContext];
+        testObject = [[NSManagedObject alloc] initWithEntity:testEntityDescription insertIntoManagedObjectContext:testManagedObjectContext];
+        
+        [testFile stub:@selector(getData) andReturn:testFileData];
+    });
+    
+    it(@"should update the Managed Object by setting the PFFile's data as the value for the key", ^{
+        NSString *testKey = @"testAttribute";
+        
+        [[testObject should] receive:@selector(setValue:forUndefinedKey:) withArguments:testFileData, testKey];
+        [testObject setPFFile:testFile forKey:testKey];
+    });
+});
+
+SPEC_END

--- a/Tests/Shared Tests/Categories/NSMutableDictionary_Tests.m
+++ b/Tests/Shared Tests/Categories/NSMutableDictionary_Tests.m
@@ -1,0 +1,35 @@
+//
+//  NSMutableDictionary_Tests.m
+//  Shared Tests
+//
+//  Created by Scott BonAmi on 3/4/14.
+//
+//
+
+#import <Kiwi/Kiwi.h>
+#import "PFIncrementalStore_PrivateMethods.h"
+
+SPEC_BEGIN(Category_NSMutableDictionary_Tests)
+
+describe(@"setPFFile:forKey:", ^{
+    __block PFFile *testFile = nil;
+    __block NSData *testFileData = nil;
+    __block NSMutableDictionary *testDictionary = nil;
+    
+    beforeEach(^{
+        testFile = [PFFile nullMock];
+        testFileData = [NSData nullMock];
+        testDictionary = [NSMutableDictionary dictionaryWithCapacity:1];
+        
+        [testFile stub:@selector(getData) andReturn:testFileData];
+    });
+    
+    it(@"should update the Dictionary by setting the PFFile's data as the value for the key", ^{
+        NSString *testKey = @"TEST KEY";
+        [testDictionary setPFFile:testFile forKey:testKey];
+        
+        [[[testDictionary objectForKey:testKey] should] equal:testFileData];
+    });
+});
+
+SPEC_END

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		963F1EAD18582B89009C50DF /* OS_X_Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 963F1EAC18582B89009C50DF /* OS_X_Test.m */; };
 		966F86CE18600D0900178A45 /* FetchRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CD18600D0900178A45 /* FetchRequest_Tests.m */; };
 		966F86D118600D3B00178A45 /* FetchRequest_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CD18600D0900178A45 /* FetchRequest_Tests.m */; };
+		96B80C0018C626C00072E190 /* NSMutableDictionary_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96B80BFF18C626C00072E190 /* NSMutableDictionary_Tests.m */; };
+		96B80C0318C62AD50072E190 /* NSManagedObject_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96B80C0218C62AD50072E190 /* NSManagedObject_Tests.m */; };
 		96C812BB1867D58D004B064E /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 962407861866CAAB00520783 /* ResourceIdentifier_Tests.m */; };
 		96C812BC1867D58E004B064E /* ResourceIdentifier_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 962407861866CAAB00520783 /* ResourceIdentifier_Tests.m */; };
 		96C812BD1867D598004B064E /* RequiredMethod_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */; };
@@ -55,6 +57,8 @@
 		963F1EAE18582B89009C50DF /* OS X Test-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OS X Test-Prefix.pch"; sourceTree = "<group>"; };
 		966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RequiredMethod_Tests.m; path = "Shared Tests/RequiredMethod_Tests.m"; sourceTree = "<group>"; };
 		966F86CD18600D0900178A45 /* FetchRequest_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FetchRequest_Tests.m; path = "Shared Tests/FetchRequest_Tests.m"; sourceTree = "<group>"; };
+		96B80BFF18C626C00072E190 /* NSMutableDictionary_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSMutableDictionary_Tests.m; path = "Shared Tests/Categories/NSMutableDictionary_Tests.m"; sourceTree = "<group>"; };
+		96B80C0218C62AD50072E190 /* NSManagedObject_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSManagedObject_Tests.m; path = "Shared Tests/Categories/NSManagedObject_Tests.m"; sourceTree = "<group>"; };
 		E84EF8B0347F4737BFABC2EC /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -167,9 +171,19 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		96B80C0118C626C50072E190 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				96B80C0218C62AD50072E190 /* NSManagedObject_Tests.m */,
+				96B80BFF18C626C00072E190 /* NSMutableDictionary_Tests.m */,
+			);
+			name = Categories;
+			sourceTree = "<group>";
+		};
 		96EE40E6185EB0C2005887CC /* Shared Tests */ = {
 			isa = PBXGroup;
 			children = (
+				96B80C0118C626C50072E190 /* Categories */,
 				962407861866CAAB00520783 /* ResourceIdentifier_Tests.m */,
 				966F86CB18600B0500178A45 /* RequiredMethod_Tests.m */,
 				966F86CD18600D0900178A45 /* FetchRequest_Tests.m */,
@@ -332,12 +346,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96B80C0018C626C00072E190 /* NSMutableDictionary_Tests.m in Sources */,
 				966F86CE18600D0900178A45 /* FetchRequest_Tests.m in Sources */,
 				9622F1051861402E00020D4C /* TestIncrementalStore.m in Sources */,
 				96C812BB1867D58D004B064E /* ResourceIdentifier_Tests.m in Sources */,
 				96C812BD1867D598004B064E /* RequiredMethod_Tests.m in Sources */,
 				963F1E9B18582B77009C50DF /* iOS_Test.m in Sources */,
 				96C812BF1867D855004B064E /* SaveRequest_Tests.m in Sources */,
+				96B80C0318C62AD50072E190 /* NSManagedObject_Tests.m in Sources */,
 				9622F1081861416900020D4C /* TestManagedObjectModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This pull request adds PFFile syncing support so that an Object attribute may
be a Parse File. This synchronously fetches the File’s data and sets that
equal to the object’s attribute.
