### PR TITLE
Add support for NSPrivateQueueConcurrencyType

### DIFF
--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -255,12 +255,12 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
             NSLog(@"Error: %@, %@", query, error);
             [self notifyManagedObjectContext:context requestIsCompleted:YES forFetchRequest:fetchRequest fetchedObjectIDs:nil];
         } else {
-            [context performBlockAndWait:^{
+            [context performBlock:^{
                 NSManagedObjectContext *childContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
                 childContext.parentContext = context;
                 childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
                 
-                [childContext performBlockAndWait:^{
+                [childContext performBlock:^{
                     [self insertOrUpdateObjects:objects ofEntity:fetchRequest.entity withContext:childContext error:nil completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
                         NSSet *childObjects = [childContext registeredObjects];
                         PFSaveManagedObjectContextOrThrowInternalConsistencyException(childContext);

--- a/PFIncrementalStore/PFIncrementalStore.m
+++ b/PFIncrementalStore/PFIncrementalStore.m
@@ -273,6 +273,8 @@ static inline void PFSaveManagedObjectContextOrThrowInternalConsistencyException
                                 NSManagedObject *parentObject = [context objectWithID:childObject.objectID];
                                 [context refreshObject:parentObject mergeChanges:YES];
                             }
+                            
+                            PFSaveManagedObjectContextOrThrowInternalConsistencyException(context);
                         }];
                         
                         [self notifyManagedObjectContext:context requestIsCompleted:YES forFetchRequest:fetchRequest fetchedObjectIDs:[managedObjects valueForKeyPath:@"objectID"]];

--- a/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
+++ b/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
@@ -76,6 +76,9 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                        forNewValuesForRelationship:(NSRelationshipDescription *)relationship
                                           forObjectWithID:(NSManagedObjectID *)objectID;
 
+// Helper Methods
+- (NSManagedObjectContext *)privateChildContextForParentContext:(NSManagedObjectContext *)parentContext;
+
 @end
 
 @interface NSManagedObject (_PFIncrementalStore)


### PR DESCRIPTION
Currently, any context that uses the `NSPrivateQueueConcurrencyType` concurrency type deadlocks on `existingObjectWithID:error:` in [`insertOrUpdateObjects:ofEntity:withContext:error:completionBlock:`](https://github.com/sbonami/PFIncrementalStore/blob/master/PFIncrementalStore/PFIncrementalStore.m#L813). This is bad!
