### PR TITLE
Fix duplicate category definition

### DIFF
--- a/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
+++ b/Tests/Mock Objects/PFIncrementalStore_PrivateMethods.h
@@ -81,7 +81,7 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 
 @end
 
-@interface NSManagedObject (_PFIncrementalStore)
+@interface NSManagedObject ()
 
 @property (readwrite, nonatomic, copy, setter = pf_setResourceIdentifier:) NSString *pf_resourceIdentifier;
 


### PR DESCRIPTION
This commit removes the duplicate category definition to fix the Xcode
warning.
