### PR TITLE
Move .travis setup into a rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: objective-c
 before_script:
   - export LANG=en_US.UTF-8
-before_install:
-    - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
-    - brew update
-    - brew uninstall xctool && brew install xctool --HEAD
-    - cd Tests && pod install && cd $TRAVIS_BUILD_DIR
 script: rake test_for_target
 env:
     - TEST_TARGET=ios

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 namespace :test do
   task :prepare do
+    system(%Q{gem install cocoapods --no-rdoc --no-ri --no-document --quiet})
+    system(%Q{brew update && brew uninstall xctool && brew install xctool --HEAD})
     system(%Q{mkdir -p "Tests/PFIncrementalStore Tests.xcodeproj/xcshareddata/xcschemes" && cp Tests/Schemes/*.xcscheme "Tests/PFIncrementalStore Tests.xcodeproj/xcshareddata/xcschemes/"})
+    system(%Q{cd Tests && pod install && cd ../})
   end
 
   desc "Run the PFIncrementalStore Tests for iOS"


### PR DESCRIPTION
This commit moves the travis setup into the prepare rake task for easier
test suite runs.
