### PR TITLE
Added To-Many relationship support when insert Parse object

### DIFF
--- a/Examples/Basic Example/Basic Example.xcodeproj/project.pbxproj
+++ b/Examples/Basic Example/Basic Example.xcodeproj/project.pbxproj
@@ -461,6 +461,7 @@
 				GCC_PREFIX_HEADER = "Basic Example/Basic Example-Prefix.pch";
 				INFOPLIST_FILE = "Basic Example/Basic Example-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "80C134EE-E2D9-4F68-B58A-6EC64120B971";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -475,6 +476,7 @@
 				GCC_PREFIX_HEADER = "Basic Example/Basic Example-Prefix.pch";
 				INFOPLIST_FILE = "Basic Example/Basic Example-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "80C134EE-E2D9-4F68-B58A-6EC64120B971";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Examples/Basic Example/Basic Example/AppDelegate.m
+++ b/Examples/Basic Example/Basic Example/AppDelegate.m
@@ -23,8 +23,8 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     
     // Override point for customization after application launch.
-    [Parse setApplicationId:<# Parse Application ID #>
-                  clientKey:<# Parse Client Key #>];
+    [Parse setApplicationId:@"FWleLi5CkEfziHZTb2RlZ1RFgZVEa7cdsjt4HpLT"
+                  clientKey:@"I4z6TfNFfC8VslUYj6uwpM8BCLwKAgSCnOikWre9"];
     
     BERootViewController *rootViewController = [[BERootViewController alloc] init];
     UINavigationController *navRootViewController = [[UINavigationController alloc] initWithRootViewController:rootViewController];

--- a/Examples/Basic Example/Basic Example/AppDelegate.m
+++ b/Examples/Basic Example/Basic Example/AppDelegate.m
@@ -23,8 +23,8 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     
     // Override point for customization after application launch.
-    [Parse setApplicationId:@"FWleLi5CkEfziHZTb2RlZ1RFgZVEa7cdsjt4HpLT"
-                  clientKey:@"I4z6TfNFfC8VslUYj6uwpM8BCLwKAgSCnOikWre9"];
+    [Parse setApplicationId:@"<#ID#>"
+                  clientKey:@"<#key#>"];
     
     BERootViewController *rootViewController = [[BERootViewController alloc] init];
     UINavigationController *navRootViewController = [[UINavigationController alloc] initWithRootViewController:rootViewController];

--- a/Examples/Basic Example/Basic Example/BERootViewController.m
+++ b/Examples/Basic Example/Basic Example/BERootViewController.m
@@ -50,7 +50,6 @@
     NSError *error = nil;
     self.fetchedResultsController.delegate = self;
     [self.fetchedResultsController performFetch:&error];
-    
     // Display an Edit button in the navigation bar for this view controller.
     self.navigationItem.rightBarButtonItem = self.editButtonItem;
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(addObject:)];
@@ -179,10 +178,7 @@
         // Delete the row from the data source
         id <NSFetchedResultsSectionInfo> tableSection = [[self.fetchedResultsController sections] objectAtIndex:indexPath.section];
         Artist *rowArtist = [[tableSection objects] objectAtIndex:indexPath.row];
-        for (Song *s in rowArtist.artistSongs) {
-            [context deleteObject:s.songGenre];
-            [context deleteObject:s];
-        }
+        
         [context deleteObject:rowArtist];
         [context save:nil];
     }

--- a/Examples/Basic Example/Basic Example/BESongViewController.m
+++ b/Examples/Basic Example/Basic Example/BESongViewController.m
@@ -34,13 +34,25 @@
     [super viewDidLoad];
     
     // Display an Edit button in the navigation bar for this view controller.
-    self.navigationItem.rightBarButtonItem = self.editButtonItem;
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(newSong:)];
+
 }
 
-- (void)didReceiveMemoryWarning
-{
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
+- (IBAction)newSong:(id)sender{
+    AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
+    NSManagedObjectContext *context = [appDelegate managedObjectContext];
+    Song *song = [NSEntityDescription insertNewObjectForEntityForName:@"Song" inManagedObjectContext:context];
+    Genre *genre = [NSEntityDescription insertNewObjectForEntityForName:@"Genre" inManagedObjectContext:context];
+    genre.genreName = [NSString stringWithFormat:@"genre_%d", arc4random_uniform(100)];
+    song.songTitle = [NSString stringWithFormat:@"song_%d", arc4random_uniform(100)];
+    song.songArtist = _artist;
+    song.songGenre = genre;
+    NSError *err;
+    [context save:&err];
+    if (err) {
+        NSLog(@"%@", err.description);
+    }
+    [self.tableView reloadData];
 }
 
 -(void)setArtist:(Artist *)artist {

--- a/Examples/Basic Example/Basic Example/Basic_Example.xcdatamodeld/Basic_Example.xcdatamodel/contents
+++ b/Examples/Basic Example/Basic Example/Basic_Example.xcdatamodeld/Basic_Example.xcdatamodel/contents
@@ -11,7 +11,7 @@
     <entity name="Song" representedClassName="Song" syncable="YES">
         <attribute name="songTitle" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="songArtist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artistSongs" inverseEntity="Artist" syncable="YES"/>
-        <relationship name="songGenre" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Genre" inverseName="genreSongs" inverseEntity="Genre" syncable="YES"/>
+        <relationship name="songGenre" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Genre" inverseName="genreSongs" inverseEntity="Genre" syncable="YES"/>
     </entity>
     <elements>
         <element name="Artist" positionX="0" positionY="0" width="128" height="75"/>

--- a/Examples/Basic Example/Basic Example/Basic_Example.xcdatamodeld/Basic_Example.xcdatamodel/contents
+++ b/Examples/Basic Example/Basic Example/Basic_Example.xcdatamodeld/Basic_Example.xcdatamodel/contents
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="3401" systemVersion="13A3017" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="5064" systemVersion="13C1021" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="Artist" representedClassName="Artist" syncable="YES">
-        <attribute name="artistName" attributeType="String" syncable="YES"/>
-        <relationship name="artistSongs" toMany="YES" deletionRule="Cascade" destinationEntity="Song" inverseName="songArtist" inverseEntity="Song" syncable="YES"/>
+        <attribute name="artistName" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="artistSongs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Song" inverseName="songArtist" inverseEntity="Song" syncable="YES"/>
     </entity>
     <entity name="Genre" representedClassName="Genre" syncable="YES">
         <attribute name="genreName" optional="YES" attributeType="String" syncable="YES"/>
-        <relationship name="genreSongs" toMany="YES" deletionRule="Nullify" destinationEntity="Song" inverseName="songGenre" inverseEntity="Song" syncable="YES"/>
+        <relationship name="genreSongs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Song" inverseName="songGenre" inverseEntity="Song" syncable="YES"/>
     </entity>
     <entity name="Song" representedClassName="Song" syncable="YES">
-        <attribute name="songTitle" attributeType="String" syncable="YES"/>
-        <relationship name="songArtist" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artistSongs" inverseEntity="Artist" syncable="YES"/>
+        <attribute name="songTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="songArtist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="artistSongs" inverseEntity="Artist" syncable="YES"/>
         <relationship name="songGenre" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Genre" inverseName="genreSongs" inverseEntity="Genre" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Artist" positionX="0" positionY="0" width="0" height="0"/>
-        <element name="Genre" positionX="0" positionY="0" width="0" height="0"/>
-        <element name="Song" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="Artist" positionX="0" positionY="0" width="128" height="75"/>
+        <element name="Genre" positionX="0" positionY="0" width="128" height="75"/>
+        <element name="Song" positionX="0" positionY="0" width="128" height="90"/>
     </elements>
 </model>


### PR DESCRIPTION
Added support to To-Many relationship when creating PFObject in:
- (void)setValuesFromManagedObject:(NSManagedObject _)managedObject withSaveCallbacks:(NSMutableDictionary *_)saveCallbacks

Fixed a bug for save callback in:
- (void)addParseSaveCallbacks:(NSArray*)callbacks forObject:(NSManagedObjectID *)objectID
